### PR TITLE
Removed the markdown from the HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,13 +698,10 @@ Conformance</span></a>
 
 
    <div class="example" id="example-1"><a class="self-link" href="#example-1"></a>
-	```css
-		.element:media( min-width: 30em ) screen {
-
-
+    <p>.element:media( min-width: 30em ) screen {</p>
+    <p>...</p>
     <p>}</p>
-	```
-</div>
+  </div>
 
 
 


### PR DESCRIPTION
The example block was using the three telda character to mark the beginning of the CSS code.
