### PR TITLE
Replace previous draft with CSS Element Queries draft

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,67 +1,1410 @@
-<pre class='metadata'>
-Title: Container Queries
-Shortname: container-queries
+<pre class=metadata>
+Title: CSS Element Queries [Level 1]
+Shortname: elementqueries
 Level: 1
-Status: ED
-Group: ricg
-URL: https://github.com/ResponsiveImagesCG/container-queries
-Editor: Mat Marquis, Bocoup http://bocoup.com
-Abstract: Container queries allow an author to control styling based on the size of a containing element rather than the size of the user’s viewport.
-!Version History: <a href="https://github.com/ResponsiveImagesCG/container-queries/commits/gh-pages">Commit History</a>
-!Version History: <a href="https://twitter.com/respimg_commits">Github commits on Twitter</a>
-!Participate: <a href="http://w3c.responsiveimages.org/">Join the Responsive Issues Community Group</a>
-!Participate: <a href="http://list.responsiveimages.org/">Public Mailing List</a>
-!Participate: <a href="irc://irc.w3.org:6665/#respimg">IRC: #respimg on the W3C IRC server</a>
-!Participate: <a href="https://twitter.com/respimg">Twitter</a>
-!Participate: <a href="https://github.com/ResponsiveImagesCG/container-queries/">GitHub</a>
+Status: DREAM
+URL: https://github.com/tomhodgins/element-queries-spec
+Repository: tomhodgins/element-query-spec
+Editor: Tommy Hodgins, tomhodgins@gmail.com
+Abstract: Element Queries allow authors to test and query values or features of elements in an HTML document. They are used in the CSS @element rule to conditionally apply styles to a document, and in various other contexts and languages, such as HTML and JavaScript.
+Abstract:
+Abstract: CSS Element Queries [Level 1] describes the mechanism and syntax of scoped styles and element queries, the responsive conditions. It also describes the meta-selectors, functions, and units that make element queries powerful.
+Logo: <img src=http://elementqueries.com/eqcss-logo.png style=width:100px;>
 </pre>
 
-Introduction {#intro}
-=====================
+<h2 id=introduction>Introduction</h2>
 
-	Given a complex responsive layout, developers often require granular control over styling elements relative to the size of their parent container rather than the viewport size. Container queries allow an author to control styling based on the size of a containing element rather than the size of the user’s viewport.
+  By default all CSS is written from the global scope ('':root'', or the HTML element), and ''@media'' queries apply globally to all elements based on the conditions of the browser and media.
 
+  The idea of a scoped style is to allow CSS to view a rule, or multiple rules from the perspective of any element in the document as though it was '':root''.
 
-## Abstract ## {#abstract}
+  Just like CSS already has ''@media'' queries which help define styles for different media conditions, this document describes functionality for an ''@element'' query syntax to define styles that target elements more specifically with conditions based on their own properties.
 
-### Limitations of Viewport-Based Media Queries ## {#mq-problems}
-(This section is not normative.)
+  <h3 id=values>Values</h3>
 
-Limiting breakpoints to viewport size fundamentally conflicts with the goal of creating modular page components, often requiring a number of redundant CSS rules and complex exception cases spanning multiple viewport-based breakpoints. This problem is compounded depending on how dramatically a module adapts at each of its breakpoints. Once viewport-based breakpoints have been tuned to suit the limited and predictable number of contexts a module might occupy, adjustments to styling elsewhere on the page (layout, width, padding/margins, etc.) may cause a need to revisit a module’s viewport-based breakpoints completely, as those styles are disconnected from the context of the module itself.
+  Value types not defined in this specification, such as <<integer>>, <<dimension>>, <<ratio>>, and <<ident>> are defined in [[!CSS3VAL]], and [[!MEDIAQUERIES-4]]
 
-## When to use Container Queries ## {#when-to-use}
+  <h3 id=units>Units</h3>
 
-	Container queries are intended for use when…
+  The units used in element queries are the same as in other parts of CSS, as defined in [[!CSS3VAL]]. For example, the pixel unit represents CSS pixels and not physical pixels.
 
-
-## Examples of Usage ## {#usage}
-
-[[Inside a CSS stylesheet, one can declare that sections apply to certain media types:]]
-
-<div class="example" id="example-1">
-	```css
-		.element:media( min-width: 30em ) screen {
-			
-		}
-	```
-</div>
+  Additionally, new <a href=#element-percentage-units>element-percentage units</a> are defined in this document which relate to an element's own properties after styles have been applied to the document.
 
 
-Container Queries {#container-queries}
-=====================
+<h2 id=element-queries>Element Queries</h2>
 
-## Syntax ## {#syntax}
+  An <strong>element query</strong> is a method of testing certain aspects of an element and applying styles based on whether that test is true or false.
 
-	The formal container query syntax is described in this section, with the rule/property grammar syntax defined in [[!CSS3SYN]] and [[!CSS3VAL]].
+  The syntax of an element query consists of a <<selector-list>>, plus an optional list of zero or more responsive conditions, followed by one or more CSS rules:
+
+  <pre class=railroad>
+    T: @element
+    N: selector list
+    Star:
+      And:
+        T: and
+        N: responsive condition
+    T: {
+    N: stylesheet
+    T: }
+  </pre>
+
+  A scoped style will return true as long as at least one element in the document matches a selector in the <<selector-list>>.
+
+  An element query is a logical expression that is either true or false. An element query is true if:
+
+  <ul>
+    <li>at least one element in the document matches a selector in the <<selector-list>>
+    <li>all responsive conditions are true
+  </ul>
+
+  User agents must re-evaluate element queries in response to changes in the user environment that they're aware of, for example resizing the browser, clicking, or scrolling, depending on which responsive conditions are being evaluated, and change the styles applied accordingly.
+
+  <h3 id=scoped-styles>Scoped Styles</h3>
+
+    To write a scoped style, write ''@element'', followed by any amount of whitespace. Wrap one or more comma-separated CSS <<selector>> in single (<code>'</code>) or double (<code>"</code>) quotes, followed by any amount of whitespace, and wrap one or more CSS rules in a pair of curly brackets (<code>{</code>,<code>}</code>).
+
+    <div class=example>
+      Example scoped style</strong>
+      <pre class=language-css>
+        @element 'html' { ... }
+      </pre>
+    </div>
+
+    <h4 id=multiple-selectors>Multiple Selectors</h4>
+
+      You can include multiple CSS selectors in your scoped style by separating them with a comma and any amount of whitespace.
+
+      <div class=example>
+        Comma-separated selector list
+        <pre class=language-css>
+          @element 'ul, ol' { ... }
+        </pre>
+      </div>
+
+    <h4 id=understanding-the-scope>Understanding the Scope</h4>
+
+    Any element on the page that matches a selector will apply the rules contained inside its scope to the page. The following examples will illustrate how the scope applies.
+
+    If we have two <code>div</code> elements in our HTML:
+    <pre class=language-html>
+      &lt;div>&lt;/div>
+      &lt;div class=demo>&lt;/div>
+    </pre>
+
+    <div class=example>
+      <pre class=language-css>
+        @element 'div' {
+          div {
+            background: lime;
+          }
+        }
+      </pre>
+      In this example, because there are two <code>div</code> elements, both will match our scope and apply a rule saying all <code>div</code> elements have a green background.
+    </div>
+
+    <div class=example>
+      <pre class=language-css>
+        @element '.demo' {
+          div {
+            background: lime;
+          }
+        }
+      </pre>
+      In this example we have one element in our HTML with a class of <code>.demo</code>. Because of this, the rule applying to all <code>div</code> elements applies to both of the <code>div</code> elements in our HTML turning their background green.
+    </div>
+
+    <div class=example>
+      <pre class=language-css>
+        @element '.demo' {
+          .demo {
+            background: lime;
+          }
+        }
+      </pre>
+      In this example we have one element in our HTML with a class of <code>.demo</code>. Because of this, the rule applying to any elements with a class of <code>.demo</code> applies and turns the background of our <code>.demo</code> element green, leaving the other <code>div</code> untouched.
+    </div>
+
+    <div class=example>
+      <pre class=language-css>
+        @element 'div' {
+          .demo {
+            background: lime;
+          }
+        }
+      </pre>
+      In this example, because there are two <code>div</code> elements, both will match our scope and apply a rule saying any element with a class of <code>.demo</code> will have a green background. This makes one of our <code>div</code> elements green and leaves the other untouched.
+    </div>
+
+    <div class=example>
+      <pre class=language-css>
+        @element 'select' {
+          .demo {
+            background: lime;
+          }
+        }
+      </pre>
+      In this example we did not have any <code>select</code> elements in our HTML, so nothing will match our scope and no styles will be applied, leaving both of our <code>div</code> elements untouched.
+    </div>
+
+    It is possible for an element to match more than one ''@element'' query.
+
+  <h3 id=scoped-styles-with-repsonsive-conditions>Scoped Styles with Responsive Conditions</h3>
+
+    An element query is a scoped style with one or more responsive conditions added.
+
+    The following global CSS and scoped style are equivalent.
+
+    <div class=example>
+      Example of global CSS
+      <pre class=language-css>
+        body {
+          background: lime;
+        }
+      </pre>
+    </div>
+
+    <div class=example>
+      Example scoped style
+      <pre class=language-css>
+        @element 'html' {
+          body {
+            background: lime;
+          }
+        }
+      </pre>
+    </div>
+
+    In both cases, as long as there is a <code>body</code> element inside of our <code>html</code>, it will have a lime background.
+
+    We can also add a responsive conditions to our scoped styles. To do this, write <code>and </code> followed by a responsive condition and value, separated by a colon (<code>:</code>) and wrapped in brackets (<code>(</code>,<code>)</code>).
+
+    <div class=example>
+      Example Element Query with Responsive Condition
+
+      <pre class=language-css>
+        @element 'html' and (min-width: 500px) {
+          body {
+            background: lime;
+          }
+        }
+      </pre>
+    </div>
+
+    In this case, our element query is equivalent to the following media query, but not every element query will be able to be expressed as a media query.
+
+    <div class=example>
+      Example media query with responsive condition
+      <pre class=language-css>
+        @media (min-width: 500px) {
+          body {
+            background: lime;
+          }
+        }
+      </pre>
+    </div>
+
+    <h4 id=multiple-conditions>Multiple Conditions</h4>
+
+      You can add more than one responsive conditions to your element query. For this, include another <code>and</code>, followed by another responsive condition as before.
+
+      <div class=example>
+        Element query with multiple responsive conditions
+        <pre class=language-css>
+          @element 'html' and (min-width: 500px) and (max-width: 1000px) {
+            body {
+              background: lime;
+            }
+          }
+        </pre>
+      </div>
+
+      Which in this case can be compared to the equivalent media query.
+
+      <div class=example>
+        Media query with multiple responsive conditions
+        <pre class=language-css>
+          @media (min-width: 500px) and (max-width: 1000px) {
+            body {
+              background: lime;
+            }
+          }
+        </pre>
+      </div>
+
+      In both cases when our <code>html</code> is between the sizes of <code>500px</code> and <code>1000px</code>, our <code>body</code> will have a lime background.
+
+    <h4 id=combining-element-and-media-queries>Combining ''@element'' and ''@media'' queries</h4>
+
+      It's possible to combine the use of scoped styles or element queries with media queries. Most of the time we combine them we want to include the media query on the inside of the element query. This will mean any time the element query is true, that media query will be visible to the browser and apply.
+
+      <div class=example>
+        Nesting a media query inside an element query
+        <pre class=language-css>
+          @element '#headline' and (min-characters: 20) {
+            @media print {
+              #headline {
+                border: 1px solid black;
+              }
+            }
+          }
+        </pre>
+      </div>
+
+      In this example, if the element with an ID of <code>#headline</code> has over 20 characters, it will display in print media with a thin black border.
+
+    <h4 id=self-referential-element-queries>Self-Referential ''@element'' queries</h4>
+
+      With element queries comes the new possibility that the rules you are applying when your responsive conditions are met will conflict with the responsive condition in your element query. In this situation we should not attempt to detect or handle these cases by ignoring certain styles, or checking whether any of the rules affect the validity of the responsive condition. It is best to apply the rule naïvely and allow the conflict to occur.
+
+      Note, The responsibility lies with the author to write ''@element'' queries which can be interpreted logically.
+
+      <div class=example>
+        <pre class=language-css>
+          @element '.widget' and (min‐width: 300px) {
+            $this {
+              width: 200px;
+            }
+          }
+        </pre>
+      </div>
+
+      In this example the query will only apply to elements with a class of <code>.widget</code> that are equal or wider than <code>300px</code>, and the rule sets a width on the same element which would make the rule no longer apply. Rather than trying to detect or intercept this behaviour and prevent it from happening, when the ''@element'' query applies to the document it will set the width to <code>200px</code>.
+
+    <h4 id=circular-referential-element-queries>Circular Referential ''@element'' queries</h4>
+
+      Another new possibility with element queries is having two or more queries that apply styles that match each others responsive condition. Just as with a self-referential ''@element'' query, we should not try to detect or ignore styles in this situation, and instead should compute the ''@element'' queries in the order they appear and apply the rules using normal CSS specificity.
+
+      <div class=example>
+        <pre class=language-css>
+          @element '.widget' and (min‐width: 400px) {
+            $this {
+              width: 200px;
+            }
+          }
+          @element '.widget' and (max‐width: 300px) {
+            $this {
+              width: 500px;
+            }
+          }
+        </pre>
+      </div>
+
+      In this example any element with a class of <code>.widget</code> that is equal to <code>400px</code> or wider will apply a rule setting the width of the same element to <code>200px</code>, which makes the following ''@element'' query valid. The second query sets a width of <code>500px</code> on the same element. In this case, even though the element now matches the responsive condition of the first query again, rather than get stuck in an infinite loop, we consider evaluation complete.
+
+<h2 id=syntax>Syntax</h3>
+
+  Informal descriptions of the element query syntax appear in the prose and railroad diagrams of the previous sections. The formal element query syntax is described in this section, with the rule/property grammar syntax defined in [[!CSS3SYN]] and [[!CSS3VAL]].
+  <pre>
+    <dfn dfn-type=at-rule>@element</dfn> = @element <<eq-prelude>> { <<stylesheet>> }
+
+    <dfn dfn-type=type>&lt;eq-prelude></dfn> = <<selector-list>> | <<selector-list>> <<eq-condition>>*
+
+    <dfn dfn-type=type>&lt;eq-condition></dfn> = and ( <<eq-name>> : <<eq-value>> )
+
+    <dfn dfn-type=type>&lt;eq-name></dfn> = min-width | max-width | min-height
+      | max-height | min-characters | max-characters
+      | min-lines | max-lines | min-children
+      | max-children | min-scroll-y | max-scroll-y
+      | min-scroll-x | max-scroll-x | orientation
+      | min-aspect-ratio | max-aspect-ratio
+
+    <dfn dfn-type=type>&lt;eq-value></dfn> = <<integer>> | <<dimension>> | <<ratio>> | <<ident>>
+
+    <dfn dfn-type=selector>meta-selectors</dfn> = $this | $parent | $prev | $next | $it
+
+    <dfn dfn-type=dfn>eq-unit</dfn> = ew | eh | emin | emax
+
+    <dfn dfn-type=function>eval("")</dfn> = eval(" ''javascript-code'' ")
+  </pre>
+
+  <h3 id=evaluating-element-queries>Evaluating Element Queries</h3>
+
+  Each <<eq-condition>> is associated with a boolean result, the same as the result of evaluating the specified responsive condition.
+
+  If the result of any responsive condition is used in any context that expects a two-valued boolean, "unknown" must be converted to "false".
+
+  Note: This means that, for example, when an element query is used in an @element rule, if it resolves to "unknown" it is treated as "false" and fails to match.
 
 
-Definitions {#defs}
-=====================
+<h2 id=meta-selectors-in-css>Meta-Selectors</h2>
 
-	The following terms are used throughout this specification so they are gathered here for the readers convenience. The following list of terms is not exhaustive; other terms are defined throughout this specification.
+  With element queries comes the need to target elements based on the scope we have defined. There are a number of new selectors that help target elements relative to the scope we have defined. These new selectors only work inside a scoped style or element query and are called ''meta-selectors''.
+
+  <h3 id=diagram-of-meta-selectors>Diagram of ''meta-selectors''</h4>
+
+  Here is a diagram showing the relationship between the meta-selectors. The <a selector>$parent</a> is the parent element of <a selector>$this</a>, and <a selector>$prev</a> and <a selector>$next</a> represent the adjacent siblings to <a selector>$this</a>.
+
+  <pre style=text-align:center;>
+    <a selector>$parent</a>
+    ↑
+    <a selector>$prev</a> ← <a selector>$this</a> → <a selector>$next</a>
+  </pre>
+
+  <dl dfn-type=selector dfn-for=meta-selectors>
+
+    <dt><dfn>$this</dfn>
+    <dd>
+      The <a selector>$this</a> meta-selector refers each element at the root of our scoped style when it matches the responsive condition.
+
+      <div class=example>
+        Example of <a selector>$this</a> meta-selector
+        <pre class=language-css>
+          @element '.widget' and (min-width: 200px) {
+            $this {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case, any element with a class of <code>.widget</code> that is <code>200px</code> or wider will have a green background.
+      </div>
+
+    <dt><dfn>$parent</dfn>
+    <dd>
+      The <a selector>$parent</a> meta-selector refers to the element containing the element(s) in the scope of our scoped style or element query.
+
+      <div class=example>
+        Example of <a selector>$parent</a> meta-selector
+        <pre class=language-css>
+          @element '.widget' and (min-width: 200px) {
+            $parent {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case, any element containing an element with a class of <code>.widget</code> that is equal or wider than <code>200px</code> will have a green background.
+      </div>
+
+    <dt><dfn>$prev</dfn>
+    <dd>
+      The <a selector>$prev</a> meta-selector refers to the sibling directly above the element at the root of our scoped style or element query.
+
+      <div class=example>
+        Example of <a selector>$prev</a> meta-selector
+        <pre class=language-css>
+          @element '.widget' {
+            $prev {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case, any sibling coming directly before any element with a class of <code>.widget</code> will have a green background.
+      </div>
+
+    <dt><dfn>$next</dfn>
+    <dd>
+      The <a selector>$next</a> meta-selector refers to the sibling directly below the element at the root of our scoped style or element query.
+
+      <div class=example>
+        Example of <a selector>$next</a> meta-selector
+        <pre class=language-css>
+          @element '.widget' {
+            $next {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case, any sibling coming directly after any element with a class of <code>.widget</code> will have a green background.
+      </div>
+
+      Note, the <a selector>$next</a> is similar to the selector: <code>$this + *</code>
+
+  </dl>
+
+<h2 id=responsive-conditions>Responsive Conditions</h2>
+
+  All responsive conditions for ''@element'' queries are formatted as a condition name and value, separated by a colon (<code>:</code>) character, surrounded by brackets (<code>()</code>).
+
+  <pre class=railroad>
+    Star:
+      And:
+        T: and
+        T: (
+        N: condition name
+        T: :
+        N: value
+        T: )
+  </pre>
+
+  The following examples are all valid as <<eq-condition>>:
+
+  <div class=example>
+    <pre class=language-css>
+      (min-width: 500px)
+    </pre>
+  </div>
+
+  <div class=example>
+    <pre class=language-css>
+      (min-aspect-ratio: 16/9)
+    </pre>
+  </div>
+
+  <div class=example>
+    <pre class=language-css>
+      (orientation: landscape)
+    </pre>
+  </div>
+
+  <h3 id=min-width>Width</h3>
+
+    <pre class="descdef mq">
+      Name: width
+      Value: <<dimension>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="width" for=@element>min-width</a> responsive condition applies to any scoped element that has greater or equal (<code>>=</code>) width to the specified value.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="width" for=@element>min-width</a> element query
+      <pre class=language-css>
+        @element '.widget' and (min-width: 200px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.widget</code> that is at least <code>200px</code> or wider will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="width" for=@element>max-width</a> responsive condition applies to any scoped element that has lesser or equal (<code><=</code>) width to the specified value.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="width" for=@element>max-width</a> element query
+      <pre class=language-css>
+        @element '.widget' and (max-width: 200) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.widget</code> that <code>200px</code> or narrower will have a green background.
+    </div>
+
+  <h3 id=height>Height</h3>
+
+    <pre class="descdef mq">
+      Name: height
+      Value: <<dimension>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="height" for=@element>min-height</a> responsive condition applies to any scoped element that has greater or equal (<code>>=</code>) height to the specified value.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="height" for=@element>min-height</a> element query
+      <pre class=language-css>
+        @element '.widget' and (min-height: 50px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.widget</code> that is at least <code>50px</code> or taller will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="height" for=@element>max-height</a> responsive condition applies to any scoped element that has lesser or equal (<code><=</code>) height to the specified value.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="height" for=@element>max-height</a> element query
+      <pre class=language-css>
+        @element '.widget' and (max-height: 50px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.widget</code> that is at least <code>50px</code> or shorter will have a green background.
+    </div>
+
+  <h3 id=characters>Characters</h3>
+
+    <pre class="descdef mq">
+      Name: characters
+      Value: <<integer>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="characters" for=@element>min-characters</a> responsive condition applies to any scoped element that contains a greater or equal (<code>>=</code>) number of characters.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="characters" for=@element>min-characters</a> element query
+      <pre class=language-css>
+        @element 'input' and (min-characters: 5) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any input with 5 or more characters will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="characters" for=@element>max-characters</a> responsive condition applies to any scoped element that contains lesser or equal (<code><=</code>) number of characters specified.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="characters" for=@element>max-characters</a> element query
+      <pre class=language-css>
+        @element 'input' and (max-characters: 5) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any input with 5 or fewer characters will have a green background.
+    </div>
+
+  <h3 id=lines>Lines</h3>
+
+    <pre class="descdef mq">
+      Name: lines
+      Value: <<integer>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="lines" for=@element>min-lines</a> responsive condition applies to any scoped element that contains greater or equal (<code>>=</code>) number of specified lines of text.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="lines" for=@element>min-lines</a> element query
+      <pre class=language-css>
+        @element 'textarea' and (min-lines: 3) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any textarea with 3 or more lines will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="lines" for=@element>max-lines</a> responsive condition applies to any scoped element that contains lesser or equal (<code><=</code>) number of specified lines of text.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="lines" for=@element>max-lines</a> element query
+      <pre class=language-css>
+        @element 'textarea' and (max-lines: 3) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any textarea with 3 or fewer lines will have a green background.
+    </div>
+
+  <h3 id=children>Children</h3>
+
+    <pre class="descdef mq">
+      Name: children
+      Value: <<integer>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="children" for=@element>min-children</a> responsive condition applies to any scoped element that contains greater or equal (<code>>=</code>) number of child elements specified.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="children" for=@element>min-children</a> element query
+      <pre class=language-css>
+        @element '.social-icons' and (min-children: 5) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.social-icons</code> that contains more 5 or more direct descendants will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="children" for=@element>max-children</a> responsive condition applies to any scoped element that contains lesser or equal (<code><=</code>) number of child elements specified.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="children" for=@element>max-children</a> element query
+      <pre class=language-css>
+        @element '.social-icons' and (max-children: 5) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.social-icons</code> that contains more 5 or fewer direct descendants will have a green background.
+    </div>
+
+  <h3 id=scroll-y>Scroll-Y</h3>
+
+    <pre class="descdef mq">
+      Name: scroll-y
+      Value: <<dimension>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="scroll-y" for=@element>min-scroll-y</a> responsive condition applies to any scoped element that has scrolled a greater or equal (<code>>=</code>) amount to the value specified in a vertical direction.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="scroll-y" for=@element>min-scroll-y</a> element query
+      <pre class=language-css>
+        @element '.feed' and (min-scroll-y: 100px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.feed</code> that has scrolled  <code>100px</code> or more vertical will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="scroll-y" for=@element>max-scroll-y</a> responsive condition applies to any scoped element that has scrolled a lesser or equal (<code><=</code>) amount to the value specified in a vertical direction.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="scroll-y" for=@element>max-scroll-y</a> element query
+      <pre class=language-css>
+        @element '.feed' and (max-scroll-y: 100px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.feed</code> that has scrolled  <code>100px</code> or less vertically will have a green background.
+    </div>
+
+  <h3 id=scroll-x>Scroll-X</h3>
+
+    <pre class="descdef mq">
+      Name: scroll-x
+      Value: <<dimension>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="scroll-x" for=@element>min-scroll-x</a> responsive condition applies to any scoped element that has scrolled a greater or equal (<code>>=</code>) amount to the value specified in a horizontal direction.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="scroll-x" for=@element>min-scroll-x</a> element query
+      <pre class=language-css>
+        @element '.feed' and (min-scroll-x: 100px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.feed</code> that has scrolled  <code>100px</code> or more horizontally will have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="scroll-x" for=@element>max-scroll-x</a> responsive condition applies to any scoped element that has scrolled a lesser or equal (<code><=</code>) amount to the value specified in a horizontal direction.
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="scroll-x" for=@element>max-scroll-x</a> element query
+      <pre class=language-css>
+        @element '.feed' and (max-scroll-x: 100px) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element with a class of <code>.feed</code> that has scrolled  <code>100px</code> or less horizontally will have a green background.
+    </div>
+
+  <h3 id=aspect-ratio>Aspect-Ratio</h3>
+
+    <pre class="descdef mq">
+      Name: aspect-ratio
+      Value: <<ratio>>
+      For: @element
+      Type: range
+    </pre>
+
+    The <a class="property" data-link-type="propdesc" data-lt="aspect-ratio" for=@element>min-aspect-ratio</a> responsive condition applies to any scoped element with a greater or equal (<code>>=</code>) aspect ratio, specified as a <code>width</code> and <code>height</code> pair, separated by a slash (<code>/</code>).
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="aspect-ratio" for=@element>min-aspect-ratio</a> element query
+      <pre class=language-css>
+        @element '.widget' and (min-aspect-ratio: 16/9) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element that had an aspect ratio of <code>16/9</code> or greater would have a green background.
+    </div>
+
+    The <a class="property" data-link-type="propdesc" data-lt="aspect-ratio" for=@element>max-aspect-ratio</a> responsive condition applies to any scoped element with a lesser or equal (<code><=</code>) aspect ratio, specified as a <code>width</code> and <code>height</code> pair, separated by a slash (<code>/</code>).
+
+    <div class=example>
+      Example <a class="property" data-link-type="propdesc" data-lt="aspect-ratio" for=@element>max-aspect-ratio</a> element query
+      <pre class=language-css>
+        @element '.widget' and (max-aspect-ratio: 16/9) {
+          $this {
+            background: lime;
+          }
+        }
+      </pre>
+      In this case any element that had an aspect ratio of <code>16/9</code> or lesser would have a green background.
+    </div>
+
+  <h3 id=orientation>Orientation</h3>
+
+    <pre class="descdef mq">
+      Name: orientation
+      Value: portrait | square | landscape
+      For: @element
+      Type: discrete
+    </pre>
+
+    The 'orientation' responsive condition applies to any scoped element that matches the orientation specified. The following orientations are included: ''landscape'', <a class="css" data-link-type="maybe" data-lt="square" for=@element/orientation>square</a>, ''portrait''
+
+    <h4 id=portrait-orientation>Portrait Orientation</h4>
+
+      <dl dfn-type=value dfn-for=@element/orientation>
+        <dt><dfn>portrait</dfn>
+        <dd>The 'orientation' is ''portrait'' if the scoped element has a greater (<code>></code>) height than width
+      </dl>
+
+      <div class=example>
+        Element query for ''portrait'' orientation</strong>
+        <pre class=language-css>
+          @element '.widget' and (orientation: portrait) {
+            $this {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case any element with a class of <code>.widget</code> that is narrower than it is tall will have a green background.
+      </div>
+
+    <h4 id=square-orientation>Square Orientation</h4>
+
+      <dl dfn-type=value dfn-for=@element/orientation>
+        <dt><dfn>square</dfn>
+        <dd>The 'orientation' is <a class="css" data-link-type="maybe" data-lt="square" for=@element/orientation>square</a> if the scoped element has an equal (<code>=</code>) height and width
+      </dl>
+
+      <div class=example>
+        Element query for <a class="css" data-link-type="maybe" data-lt="square" for=@element/orientation>square</a> orientation</strong>
+        <pre class=language-css>
+          @element '.widget' and (orientation: square) {
+            $this {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case any element with a class of <code>.widget</code> that has an equal width and height will have a green background.
+      </div>
+
+    <h4 id=landscape-orientation>Landscape Orientation</h4>
+
+      <dl dfn-type=value dfn-for=@element/orientation>
+        <dt><dfn>landscape</dfn>
+        <dd>The 'orientation' is ''landscape'' if the scoped element has a greater (<code>></code>) width than height
+      </dl>
+
+      <div class=example>
+        Element query for ''landscape'' orientation</strong>
+        <pre class=language-css>
+          @element '.widget' and (orientation: landscape) {
+            $this {
+              background: lime;
+            }
+          }
+        </pre>
+        In this case any element with a class of <code>.widget</code> that is wider than it is tall will have a green background.
+      </div>
+
+<h2 id=css-functions>CSS Functions</h2>
+
+  <h3 id=eval>eval("")</h3>
+
+    Note, Much of the functionality of this feature is similar to CSS variables, however being able to execute JavaScript from the vantage point of the element in the scope could perhaps be a way that CSS variables could be used a little differently inside scoped styles or element queries.
+
+    The <a>eval("")</a> function can be used anywhere inside a scoped style or element query. It shares a scope with the element in the root of the scoped style.
+
+    <pre class=railroad>
+      T: eval("
+      N: javascript
+      T: ")
+    </pre>
+
+    When using <a>eval("")</a> you can write <code>eval</code>, followed by a pair of brackets (<code>(</code>,<code>)</code>) which contain JavaScript code, wrapped in either single (<code>'</code>) or double (<code>"</code>) quotes.
+
+    This JavaScript can do something simple like reference the value of a variable, perform a simple calculation inline, or it can use the value return by a function.
+
+      Note, Unlike CSS variables, the <a>eval("")</a> function can be used anywhere in CSS: as a value, a property name, a selector, a '@media' query breakpoint - it can be used for anything, as long as it is inside of a scoped style.
+
+    <h4 id=using-js-variables-in-css>Using JavaScript Variables in CSS</h4>
+
+      <div class=example>
+        Accessing a JavaScript variable with <a>eval("")</a></strong>
+        <pre class=language-html>
+          &lt;script>
+            var brandColor = 'lime'
+          &lt;/script>
+
+          &lt;style>
+            @element '.widget' {
+              $this {
+                background: eval("brandColor");
+              }
+            }
+          &lt;/style>
+        </pre>
+        In this case any element with a class of <code>.widget</code> will have a green background.
+      </div>
+
+      <h4 id=writing-js-in-css>Writing JavaScript in CSS</h4>
+
+      <div class=example>
+        Evaluating JavaScript Inline with <a>eval("")</a>
+        <pre class=language-css>
+          @element '.widget' {
+            font-size: eval("10 * 2")px;
+          }
+        </pre>
+        In this case our inline JavaScript (<code>10 * 2</code>) evaluates in place, leaving us with a font size of <code>20px</code>.
+      </div>
+
+      <h4 id=using-js-functions-in-css>Using JavaScript Functions in CSS</h4>
+
+      <div class=example>
+        Using Values Returned from Functions with <a>eval("")</a></strong>
+        <pre class=language-html>
+          &lt;script>
+            function addTen(number){
+              var number = parseInt(number) || 0
+              return number + 10
+            }
+          &lt;/script>
+
+          &lt;style>
+            @element '.widget' {
+              font-size: eval("addTen(15)")px;
+            }
+          &lt;/style>
+        </pre>
+        In this case any element with a class of <code>.widget</code> will have a font size of <code>25px</code>.
+      </div>
+
+    <h4 id=replacing-values-in-css>Replacing Values in CSS</h4>
+
+      <div class=example>
+        Here is <a>eval("")</a> being used as a value:
+        <pre class=language-html>
+          &lt;script>
+            var blue = '#07f'
+          &lt;/script>
+
+          &lt;style>
+            @element 'div' {
+              $this {
+                color: eval("blue");
+              }
+            }
+          &lt;/style>
+        </pre>
+        This example would be equivalent to: <code>div { color: #07f; }</code>
+      </div>
+
+    <h4 id=replacing-properties-in-css>Replacing Properties in CSS</h4>
+
+      <div class=example>
+        Here is <a>eval("")</a> being used as a property:
+        <pre class=language-html>
+          &lt;input>
+          &lt;script>
+            var browser = /Safari/.test(navigator.userAgent) ? '-webkit-':''
+          &lt;/script>
+
+          &lt;style>
+            @element 'input' {
+              $this {
+                eval('browser')appearance: none;
+              }
+            }
+          &lt;/style>
+        </pre>
+        This example would use the property: <code>-webkit-appearance</code> if the browser was Safari, otherwise would use: <code>appearance</code>.
+      </div>
+
+    <h4 id=replacing-selectors-in-css>Replacing Selectors in CSS</h4>
+
+      <div class=example>
+        Here is <a>eval("")</a> replacing a list of selectors:
+        <pre class=language-html>
+          &lt;script>
+            var buttonish = '[type=button], [type=submit], [type=reset], button'
+          &lt;/script>
+
+          &lt;style>
+            @element 'html' {
+              eval('buttonish') {
+                appearance: none;
+                color: black;
+                background: white;
+                border: 1px solid currentColor;
+              }
+            }
+          &lt;/style>
+        </pre>
+        This example would be equivalent the following rule:
+        <pre class=language-css>
+          [type=button], [type=submit], [type=reset], button {
+            appearance: none;
+            color: black;
+            background: white;
+            border: 1px solid currentColor;
+          }
+        </pre>
+        Check the <a href=#using-variables-as-selectors>Using Variables as Selectors</a> example below for a more elaborate demonstration, including pseudo-classes like <code>:hover</code> or <code>:focus</code>
+      </div>
+
+      Note, Because <a>eval("")</a> works everywhere in CSS inside of a scoped style, it's also possible to use inside the 'content' property for pseudo-elements like ''before'' and ''after''.
+
+    <h4 id=it-selector><code>$it</code> selector</h4>
+
+<dl dfn-type=selector dfn-for=meta-selectors>
+
+    <dt><dfn>$it</dfn>
+    <dd>
+      By default the inline evaluation of <a>eval("")</a> shares the same scope in JavaScript as the scoped element. This means for a scoped style like <code>@element '.widget' {}</code>, things like <code>innerHTML</code> represent the <code>innerHTML</code> of the elements with <code>.widget</code>. This would also apply individually to each element if more than one element on the page matches that selector. In this example we can use <code>parentNode</code> inside of <a>eval("")</a> to check how many child elements the parent element holding any <code>.widget</code> element contains.
+
+      <div class=example>
+        Example of ''eval("")'' with Implicit Context
+        <pre class=language-css>
+          @element '.widget' {
+            $this:before {
+              content: 'eval("parentNode.children.length")';
+            }
+          }
+        </pre>
+        In this case the pseudo-element <code>:before</code> the content of any element with a class of <code>.widget</code> will contain text of the number of child elements inside the parent element of our <code>.widget</code> element.
+      </div>
+
+      The meta-selector <a selector>$it</a> works inside <a>eval("")</a> as a placeholder for the scoped element. The following example is functionally equivalent to the last example:
+
+      <div class=example>
+        Example of <a>eval("")</a> with the <a selector>$it</a> Selector
+        <pre class=language-css>
+          @element '.widget' {
+            $this:before {
+              content: 'eval("$it.parentNode.children.length")';
+            }
+          }
+        </pre>
+      </div>
+
+    </dl>
+
+<h2 id=element-percentage-units>Element-percentage Units</h2>
+
+  Just as CSS has viewport-percentage units: ''vw'', ''vh'', ''vmin'', and ''vmax'' which represent a distance equal to 1% of the viewport width, height, shortest edge, and longest edge, in a similar way the following element-percentage units ''ew'', ''eh'', ''emin'', and ''emax'' represent a distance equal to 1% of the element's own width, height, shortest edge, and longest edge. When the width of height of the element changes, the value of these units scale accordingly.
+
+  Note, These new <a dfn>eq-unit</a> units always refer to the dimensions of the element in the scope, and can be used inside of a scoped style or element query to style other elements.
+
+  <dl dfn-type=value dfn-for=eq-unit>
+
+    <dt><dfn id=ew lt=ew>ew unit</dfn>
+    <dd>
+      Equal to 1% of the width of the scoped element
+
+      <div class=example>
+        Example of ew Units Inside a Scoped Style
+        <pre class=language-css>
+          @element '.widget' {
+            $this {
+              font-size: 10ew;
+            }
+          }
+        </pre>
+        In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element's width.
+      </div>
+
+      Note, This unit is similar to the ''vw'' viewport unit, but based on the scoped element's dimensions.
+
+    <dt><dfn id=eh lt=eh>eh unit</dfn>
+    <dd>
+      Equal to 1% of the height of the scoped element
+
+      <div class=example>
+        Example of eh Units Inside a Scoped Style
+        <pre class=language-css>
+          @element '.widget' {
+            $this {
+              font-size: 10eh;
+            }
+          }
+        </pre>
+        In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element's height.
+      </div>
+
+      Note, This unit is similar to the ''vh'' viewport unit, but based on the scoped element's dimensions.
+
+    <dt><dfn id=emin lt=emin>emin unit</dfn>
+    <dd>
+      Equal to the smaller of ew or eh
+
+      <div class=example>
+        Example of emin Units Inside a Scoped Style
+        <pre class=language-css>
+          @element '.widget' {
+            $this {
+              font-size: 10emin;
+            }
+          }
+        </pre>
+        In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element's shortest edge.
+      </div>
+
+      Note, This unit is similar to the ''vmin'' viewport unit, but based on the scoped element's dimensions.
+
+    <dt><dfn id=emax lt=emax>emax unit</dfn>
+    <dd>
+      Equal to the larger of ew or eh
+
+      <div class=example>
+        Example of emax Units Inside a Scoped Style
+        <pre class=language-css>
+          @element '.widget' {
+            $this {
+              font-size: 10emax;
+            }
+          }
+        </pre>
+        In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element's longest edge.
+      </div>
+
+      Note, This unit is similar to the ''vmax'' viewport unit, but based on the scoped element's dimensions.
+
+  </dl>
+
+<h2 id=examples-of-element-queries>Examples of Scoped Styles & Element Queries</h2>
+
+<h3 id=example-scoped-styles>Examples of valid scoped styles</h3>
+
+  <div class=example>
+    <pre class=language-css>
+      @element 'div' {}
+    </pre>
+  </div>
+
+  <div class=example>
+    <pre class=language-css>
+      @element 'div, span' {}
+    </pre>
+  </div>
+
+  <div class=example>
+    <pre class=language-css>
+      @element 'div' and (min-width: 500px) {}
+    </pre>
+  </div>
+
+  <div class=example>
+    <pre class=language-css>
+      @element 'div' and (min-width: 500px) and (min-lines: 3) {}
+    </pre>
+  </div>
 
 
-Acknowledgements {#acks}
-=====================
+<h3 id=wrapper-free-responsive-iframe>Wrapper-free responsive iframe resize</h3>
 
-	A <a href="http://www.w3.org/community/respimg/participants">complete list of participants</a> of the Responsive Issues Community Group is available at the W3C Community Group Website.
+  <div class=example>
+    <pre class=language-html>
+      &lt;iframe width="640" height="360">&lt;/iframe>
+      &lt;style>
+        @element 'iframe' {
+          $this {
+            width: 100%;
+            height: eval('offsetWidth / (width / height)')px;
+          }
+        }
+      &lt;/style>
+    </pre>
+    In this example the <code>iframe</code> element has a <code>width=""</code> and <code>height=""</code> attribute supplied in HTML which is being accessed from CSS using <code>$it.width</code> and <code>$it.height</code> inside our <a>eval("")</a> function. Because we are able to compute the HTML attributes directly, this one rule will make multiple <code>iframe</code> elements with <em>different</em> attribute values on the same page responsive, as it computes each iframe separately as <code>$this</code>.
+  </div>
+
+<h3 id=faking-input-empty>Faking <code>input:empty</code></h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;input>
+      &lt;style>
+        /* input:empty */
+        @element 'input' and (max-characters: 0) {
+          $this {
+            background: red;
+          }
+        }
+        /* input:not(:empty) */
+        @element 'input' and (min-characters: 1) {
+          $this {
+            background: lime;
+          }
+        }
+      &lt;/style>
+    </pre>
+    In this example we are able to apply styles based on whether there are zero or at least one characters inside any <code>input</code> element. CSS has the pseudo-class '':empty'', however it doesn't apply to all elements (like <code>input</code> elements) so by using <code>max-characters</code> and <code>min-characters</code> with element queries we are able to express and style a similar idea.
+  </div>
+
+<h3 id=auto-expanding-textarea>Auto-expanding <code>textarea</code></h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;textarea>&lt;/textarea>
+      &lt;style>
+        @element 'textarea' {
+          $this {
+            height: eval("style.height='inherit';style.height=scrollHeight+'px'");
+          }
+        }
+      &lt;/style>
+    </pre>
+    In this example we are using <a>eval("")</a> to reset the height value of our element and immediately set it to the scrollHeight of the element, ensuring that no matter how many lines of text it contains, it will always expand & contract to contain all of them.
+  </div>
+
+<h3 id=display-browser-dimensions>Display Browser Dimensions</h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;style>
+        @element ':root' {
+          $this:before {
+            content: 'eval("window.innerWidth") × eval("window.innerHeight")';
+            position: fixed;
+            top: .5em;
+            left: .5em;
+          }
+        }
+      &lt;/style>
+    </pre>
+    This example will create a new pseudo-element on our ':root' element (the HTML element) and uses <a>eval("")</a> to display the <code>innerWidth</code> and <code>innerHeight</code> values of our <code>window</code>.
+  </div>
+
+<h3 id=self-responsive-grid>Self-responsive Grid</h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;h2>Responsive Grid&lt;/h2>
+      &lt;p>Small = full width, Medium = thirds, Large = sixths.&lt;/p>
+      &lt;section data-grid>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+        &lt;div class="col-10 medium-split-3 large-split-6">&lt;/div>
+      &lt;/section>
+      &lt;h2>Split Grid&lt;/h2>
+      &lt;p>Small = half width, Medium = 1, 2, 3, 4 split, Large = 4, 3, 2, 1 split.&lt;/p>
+      &lt;section data-grid>
+        &lt;div class="col-5 medium-split-1 large-split-4">&lt;/div>
+        &lt;div class="col-5 medium-split-2 large-split-4">&lt;/div>
+        &lt;div class="col-5 medium-split-2 large-split-4">&lt;/div>
+        &lt;div class="col-5 medium-split-3 large-split-4">&lt;/div>
+        &lt;div class="col-5 medium-split-3 large-split-3">&lt;/div>
+        &lt;div class="col-5 medium-split-3 large-split-3">&lt;/div>
+        &lt;div class="col-5 medium-split-4 large-split-3">&lt;/div>
+        &lt;div class="col-5 medium-split-4 large-split-2">&lt;/div>
+        &lt;div class="col-5 medium-split-4 large-split-2">&lt;/div>
+        &lt;div class="col-5 medium-split-4 large-split-1">&lt;/div>
+      &lt;/section>
+      &lt;h2>Hidden Elements&lt;/h2>
+      &lt;p>Small = Hide Small, Medium = Hide Medium, Large = Hide Large.&lt;/p>
+      &lt;section data-grid>
+        &lt;div class="col-10 hide-small">Small&lt;/div>
+        &lt;div class="col-10 hide-medium">Medium&lt;/div>
+        &lt;div class="col-10 hide-large">Large&lt;/div>
+      &lt;/section>
+      &lt;style>
+        * {
+          box-sizing: border-box;
+        }
+        [data-grid] div {
+          min-height: 50px;
+          background: lime;
+          border: 5px solid white;
+        }
+        /* Element Query Grid */
+        @element '[data-grid]' {
+          $this,
+          $this * {
+            box-sizing: border-box;
+          }
+          $this:after,
+          $this [data-row]:after {
+            content: '';
+            display: block;
+            clear: both;
+          }
+          $this [class*=-col-],
+          $this [class*=-split-] { float: left; }
+          $this [class^=col-1] { width: 10%; }
+          $this [class^=col-2] { width: 20%; }
+          $this [class^=col-3] { width: 30%; }
+          $this [class^=col-4] { width: 40%; }
+          $this [class^=col-5] { width: 50%; }
+          $this [class^=col-6] { width: 60%; }
+          $this [class^=col-7] { width: 70%; }
+          $this [class^=col-8] { width: 80%; }
+          $this [class^=col-9] { width: 90%; }
+          $this [class^=col-10] { width: 100%; }
+          $this [class^=split-1] { width: calc(100%/1); }
+          $this [class^=split-2] { width: calc(100%/2); }
+          $this [class^=split-3] { width: calc(100%/3); }
+          $this [class^=split-4] { width: calc(100%/4); }
+          $this [class^=split-5] { width: calc(100%/5); }
+          $this [class^=split-6] { width: calc(100%/6); }
+          $this [class^=split-7] { width: calc(100%/7); }
+          $this [class^=split-8] { width: calc(100%/8); }
+          $this [class^=split-9] { width: calc(100%/9); }
+          $this [class^=split-10] { width: calc(100%/10); }
+        }
+        @element '[data-grid]' and (max-width: 400px) {
+          $this [class*=small-col-1] { width: 10%; }
+          $this [class*=small-col-2] { width: 20%; }
+          $this [class*=small-col-3] { width: 30%; }
+          $this [class*=small-col-4] { width: 40%; }
+          $this [class*=small-col-5] { width: 50%; }
+          $this [class*=small-col-6] { width: 60%; }
+          $this [class*=small-col-7] { width: 70%; }
+          $this [class*=small-col-8] { width: 80%; }
+          $this [class*=small-col-9] { width: 90%; }
+          $this [class*=small-col-10] { width: 100%; }
+          $this [class*=small-split-1] { width: calc(100%/1); }
+          $this [class*=small-split-2] { width: calc(100%/2); }
+          $this [class*=small-split-3] { width: calc(100%/3); }
+          $this [class*=small-split-4] { width: calc(100%/4); }
+          $this [class*=small-split-5] { width: calc(100%/5); }
+          $this [class*=small-split-6] { width: calc(100%/6); }
+          $this [class*=small-split-7] { width: calc(100%/7); }
+          $this [class*=small-split-8] { width: calc(100%/8); }
+          $this [class*=small-split-9] { width: calc(100%/9); }
+          $this [class*=small-split-10] { width: calc(100%/10); }
+          $this [class*=hide-small] { display: none; }
+        }
+        @element '[data-grid]' and (min-width: 400px) and (max-width: 800px) {
+          $this [class*=medium-col-1] { width: 10%; }
+          $this [class*=medium-col-2] { width: 20%; }
+          $this [class*=medium-col-3] { width: 30%; }
+          $this [class*=medium-col-4] { width: 40%; }
+          $this [class*=medium-col-5] { width: 50%; }
+          $this [class*=medium-col-6] { width: 60%; }
+          $this [class*=medium-col-7] { width: 70%; }
+          $this [class*=medium-col-8] { width: 80%; }
+          $this [class*=medium-col-9] { width: 90%; }
+          $this [class*=medium-col-10] { width: 100%; }
+          $this [class*=medium-split-1] { width: calc(100%/1); }
+          $this [class*=medium-split-2] { width: calc(100%/2); }
+          $this [class*=medium-split-3] { width: calc(100%/3); }
+          $this [class*=medium-split-4] { width: calc(100%/4); }
+          $this [class*=medium-split-5] { width: calc(100%/5); }
+          $this [class*=medium-split-6] { width: calc(100%/6); }
+          $this [class*=medium-split-7] { width: calc(100%/7); }
+          $this [class*=medium-split-8] { width: calc(100%/8); }
+          $this [class*=medium-split-9] { width: calc(100%/9); }
+          $this [class*=medium-split-10] { width: calc(100%/10); }
+          $this [class*=hide-medium] { display: none; }
+        }
+        @element '[data-grid]' and (min-width: 800px) {
+          $this [class*=large-col-1] { width: 10%; }
+          $this [class*=large-col-2] { width: 20%; }
+          $this [class*=large-col-3] { width: 30%; }
+          $this [class*=large-col-4] { width: 40%; }
+          $this [class*=large-col-5] { width: 50%; }
+          $this [class*=large-col-6] { width: 60%; }
+          $this [class*=large-col-7] { width: 70%; }
+          $this [class*=large-col-8] { width: 80%; }
+          $this [class*=large-col-9] { width: 90%; }
+          $this [class*=large-col-10] { width: 100%; }
+          $this [class*=large-split-1] { width: calc(100%/1); }
+          $this [class*=large-split-2] { width: calc(100%/2); }
+          $this [class*=large-split-3] { width: calc(100%/3); }
+          $this [class*=large-split-4] { width: calc(100%/4); }
+          $this [class*=large-split-5] { width: calc(100%/5); }
+          $this [class*=large-split-6] { width: calc(100%/6); }
+          $this [class*=large-split-7] { width: calc(100%/7); }
+          $this [class*=large-split-8] { width: calc(100%/8); }
+          $this [class*=large-split-9] { width: calc(100%/9); }
+          $this [class*=large-split-10] { width: calc(100%/10); }
+          $this [class*=hide-large] { display: none; }
+        }
+      &lt;/style>
+    </pre>
+    This example uses ''@element'' queries to apply the different responsive styles to our grid when the grid element itself reaches certain breakpoints. Because the styles are scoped to each grid using <a selector>$this</a>, we can use these same styles to power many grids in the same layout all using the same styles.
+  </div>
+
+<h3 id=using-variables-as-selectors>Using Variables as Selectors</h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;input type=hidden placeholder=hidden>
+      &lt;input type=text placeholder=text>
+      &lt;input type=search placeholder=search>
+      &lt;input type=tel placeholder=tel>
+      &lt;input type=url placeholder=url>
+      &lt;input type=email placeholder=email>
+      &lt;input type=password placeholder=password>
+      &lt;input type=date placeholder=date>
+      &lt;input type=month placeholder=month>
+      &lt;input type=week placeholder=week>
+      &lt;input type=time placeholder=time>
+      &lt;input type=datetime-local placeholder=datetime-local>
+      &lt;input type=number placeholder=number>
+      &lt;input type=color placeholder=color>
+      &lt;textarea>textarea&lt;/textarea>
+      &lt;script>
+        var textish = [
+          '[type=text]', '[type=search]', '[type=tel]', '[type=url]', '[type=email]', '[type=password]', '[type=date]', '[type=month]', '[type=week]', '[type=time]', '[type=datetime-local]', '[type=number]', '[type=color]', 'textarea'
+        ]
+        /* return selectors with :states using action(array,state) */
+        function action(array,state){
+          var selectors = '';
+          for(i=0; i&lt;array.length; i++){
+            selectors += array[i]+':'+state
+            if (i &lt; array.length-1){
+              selectors += ', '
+            }
+          }
+          return selectors
+        }
+      &lt;/script>
+      &lt;style>
+        /* set width for most inputs */
+        @element ':root' {
+          /* Style all selectors in 'textish' array */
+          eval('textish') {
+            display: block;
+            width: 100%;
+          }
+          /* Add ':hover' to all selectors in 'textish' array */
+          eval('action(textish,"hover")') {
+            background: lime;
+          }
+          /* Add ':focus' to all selectors in 'textish' array */
+          eval('action(textish,"focus")') {
+            background: red;
+          }
+        }
+      &lt;/style>
+    </pre>
+    In this example we use <a>eval("")</a> to return either a list of selectors (stored as strings in a JavaScript array) or we use the return from a function that allows us to append strings like ':hover', or ':focus' to each selector as it gives them to use as a selector or selector list in our CSS inside of a scoped style. For manipulating or styling many similar things (like text-style inputs but not other inputs) we can simplify the selectors we need to use throughout our CSS while maintaining full control over what gets styled.
+  </div>
+
+<h3 id=clamped-numbers-in-CSS>Clamped Numbers in CSS</h3>
+
+  <div class=example>
+    <pre class=language-html>
+      &lt;h1>Headline&lt;/h1>
+      &lt;script>
+        function clamp(min,mid,max){
+          return Math.min(Math.max(min,mid),max)
+        }
+      &lt;/script>
+      &lt;style>
+        @element 'h1' {
+          $this {
+            font-size: eval('clamp(50,innerWidth/10,100)')px;
+          }
+        }
+      &lt;/style>
+    </pre>
+    In this example our font size prefers to be equal to <code>window.innerWidth/10</code> pixels wide, but our JavaScript function will clamp that value for us, ensuring that if <code>innerWidth/10</code> is less than 50, our font size will go no lower than <code>50px</code>, and if <code>innerWidth/10</code> is greater than 100, our font size will grow no larger than <code>100px</code>.
+  </div>

--- a/index.html
+++ b/index.html
@@ -1,784 +1,3524 @@
-<!doctype html>
-<html lang="en">
+<!doctype html><html lang="en">
  <head>
-  
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  
-  
-  <title>Container Queries</title>
-  
-  
-  <style>
-@media print {
-  html { margin: 0 !important; }
-  body { font-family: serif; }
-  th, td { font-family: inherit; }
-  a { color: inherit !important; }
-  .example:before { font-family: serif !important; }
-  a:link, a:visited { text-decoration: none !important; }
-  a:link:after, a:visited:after { /* create a cross-ref "see..." */; }
-}
-@page {
-  margin: 1.5cm 1.1cm;
-}
-h1, h2, h3, h4, h5, h6 { page-break-after: avoid; }
-figure, div.figure, div.sidefigure, pre, table.propdef, table.propdef-extra,
-.example { page-break-inside: avoid; }
-dt { page-break-after: avoid; }
+  <title>CSS Element Queries [Level 1]</title>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .assertion  for assertions                    (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure) " ";  }
+ *        .example::before { content: "Example " counter(example) " "; }
+ *        .issue::before   { content: "Issue "   counter(issue) " ";   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
 
-body {
-  background: white;
-  /* background-image: floating-margin-image-goes-here; */
-  background-position: top left;
-  background-attachment: fixed;
-  background-repeat: no-repeat;
-  color: black;
-  counter-reset: exampleno figure issue;
-  font-family: sans-serif;
-  line-height: 1.5;
-  margin: 0 auto;
-  max-width: 50em;
-  padding: 2em 1em 2em 70px;
-}
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
 
-/* General structural markup */
+	body {
+		counter-reset: example figure issue;
 
-h1, h2, h3, h4, h5, h6 { text-align: left; }
-h1, h2, h3 { color: #005A9C; }
-h1 { font: 170% sans-serif; }
-h2 { font: 140% sans-serif; }
-h3 { font: 120% sans-serif; }
-h4 { font: bold 100% sans-serif; }
-h5 { font: italic 100% sans-serif; }
-h6 { font: small-caps 100% sans-serif; }
-h2, h3, h4, h5, h6 { margin-top: 3em; }
-h1 + h2 { margin-top: 0em; }
-h2 + h3, h3 + h4, h4 + h5, h5 + h6 { margin-top: 1.2em; }
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
 
-.head { margin-bottom: 1em; }
-.head h1 { margin-top: 2em; clear: both; }
-.head table { margin-left: 2em; margin-top: 2em; }
-.head dd { margin-bottom: 0; }
+		/* Typography */
+		line-height: 1.5;
+		font-family: sans-serif;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
 
-p.copyright { font-size: small; }
-p.copyright small { font-size: small; }
-
-pre { margin: 1em 0 1em 2em; overflow: auto; }
-pre, code, .idl-code {
-  font-size: .9em;
-  font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-}
-dt dfn code { font-size: inherit; }
-
-dfn { font-weight: bolder; }
-dfn var { font-style: normal; }
-
-s, del {text-decoration: line-through; color: red; }
-u, ins {text-decoration: underline; background: #bfa; }
-
-sup {
-  vertical-align: super;
-  font-size: 80%
-}
-
-details { display: block; }
-
-dt { font-weight: bold; }
-dd { margin: 0 0 1em 2em; }
-ul, ol { margin-left: 0; padding-left: 2em; }
-li { margin: 0.25em 2em 0.5em 0; padding-left: 0; }
-[data-md] > :first-child { margin-top: 0; }
-[data-md] > :last-child { margin-bottom: 0; }
-
-td.pre {
-  white-space: pre-wrap;
-}
-
-.css, .property { color: #005a9c; }
-.property { white-space: nowrap; }
-
-
-/* Boilerplate sections */
-
-ul.indexlist { margin-left: 0; columns: 13em; }
-ul.indexlist li { margin-left: 0; list-style: none }
-ul.indexlist li li { margin-left: 1em; }
-ul.indexlist a { font-weight: bold; }
-ul.indexlist ul, ul.indexlist dl { font-size: smaller; }
-ul.indexlist dl { margin-top: 0; }
-ul.indexlist dt { margin: .2em 0 .2em 20px; }
-ul.indexlist dd { margin: .2em 0 .2em 40px; }
-
-.toc {
-  font-weight: bold;
-  line-height: 1.3;
-  list-style: none;
-  margin: 1em 0 0 5em;
-  padding: 0;
-}
-.toc ul { margin: 0; padding: 0; font-weight: normal; }
-.toc ul ul { margin: 0 0 0 2em; font-style: italic; }
-.toc ul ul ul { margin: 0}
-.toc > li { margin: 1.5em 0; padding: 0; }
-.toc li { clear: both; }
-.toc ul.toc li { margin: 0.3em 0 0 0; }
-.toc a { border-bottom-style: none; }
-.toc a:hover, ul.toc a:focus { border-bottom-style: solid; }
-/* Section numbers in a column of their own */
-.toc span.secno {float: left; width: 4em; margin-left: -5em}
-.toc ul ul span.secno { margin-left: -7em; }
-
-table.proptable {
-  font-size: small;
-  border-collapse: collapse;
-  border-spacing: 0;
-  text-align: left;
-  margin: 1em 0;
-}
-table.proptable td, table.proptable th {
-  padding: 0.4em;
-  text-align: center;
-}
-table.proptable tr:hover td { background: #DEF; }
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px auto;
+	}
 
 
-/* Links */
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
 
-a[href] { color: inherit; border-bottom: 1px solid silver; text-decoration: none; }
-a[href]:hover { background: #ffa; }
-a[href]:active { color: #C00; background: transparent; }
-img, a.logo { border-style: none; }
-.heading, .issue, .note, .example, li, dt { position: relative; }
-/* CSS-ish link types */
-[data-link-type="property"]::before,
-[data-link-type="propdesc"]::before,
-[data-link-type="descriptor"]::before,
-[data-link-type="value"]::before,
-[data-link-type="function"]::before,
-[data-link-type="at-rule"]::before,
-[data-link-type="selector"]::before,
-[data-link-type="maybe"]::before {content: "“";}
-[data-link-type="property"]::after,
-[data-link-type="propdesc"]::after,
-[data-link-type="descriptor"]::after,
-[data-link-type="value"]::after,
-[data-link-type="function"]::after,
-[data-link-type="at-rule"]::after,
-[data-link-type="selector"]::after,
-[data-link-type="maybe"]::after {content: "”";}
-[data-link-type].production::before,
-[data-link-type].production::after,
-.prod [data-link-type]::before,
-.prod [data-link-type]::after { content: ""; }
-/* Element-type link styling */
-[data-link-type=element] { font-family: monospace; }
-[data-link-type=element]::before { content: "<" }
-[data-link-type=element]::after { content: ">" }
-/* Self-links */
-a.self-link {
-  position: absolute;
-  top: 0;
-  left: -2.5em;
-  width: 2em;
-  height: 2em;
-  text-align: center;
-  border: none;
-  transition: opacity .2s;
-  opacity: .5;
-}
-a.self-link:hover {
-  opacity: 1;
-}
-.heading > a.self-link {
-  font-size: 83%;
-}
-li > a.self-link {
-  left: -3.5em;
-}
-dfn > a.self-link {
-  top: auto;
-  left: auto;
-  opacity: 0;
-  width: 1.5em;
-  height: 1.5em;
-  background: gray;
-  color: white;
-  font-style: normal;
-  transition: opacity .2s, background-color .2s, color .2s;
-}
-dfn:hover > a.self-link {
-  opacity: 1;
-}
-dfn > a.self-link:hover {
-  color: black;
-}
-a.self-link::before { content: "¶"; }
-.heading > a.self-link::before { content: "§"; }
-dfn > a.self-link::before { content: "#"; }
+/** Header ********************************************************************/
+
+	div.head { margin-bottom: 1em }
+	div.head hr { border-style: solid; }
+
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
+	}
+
+	div.head h2 { margin-bottom: 1.5em;}
+
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		color: white;
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		border-color: #c00;
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+			color: black;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			background: white;
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+			background: white;
+		}
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			background: #f8f8f8;
+		}
+		#toc-nav > a:not(:hover):not(:focus) {
+			color: #707070;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		#toc-nav :active {
+			color: #C00;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
+	}
+
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
+	}
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
+	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+
+	:not(.head) > hr {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		border: transparent solid 0;
+		background: transparent;
+	}
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
+	}
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+
+	dd > p:first-child,
+	li > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+
+	li {
+		margin: 0.25em 0 0.5em;
+		padding: 0;
+	}
+
+	dl dd {
+		margin: 0 0 .5em 2em;
+	}
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
+	}
+
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+	  padding: .5em;
+	  border: thin solid #ddd; border-radius: .5em;
+	  margin: .5em 0;
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+	  margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+	  margin-bottom: 0;
+	}
+
+	/* Style for switch/case <dl>s */
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+/** Terminology Markup ********************************************************/
 
 
-/* Figures */
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
 
-figure {
-  display: block;
-  text-align: center;
-  margin: 2.5em 0;
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: normal;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del { color: red;  text-decoration: line-through; }
+	ins { color: #080; text-decoration: underline;    }
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+		font-size: .9em;
+		page-break-inside: avoid;
+		hyphens: none;
+		text-transform: none;
+	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Inline Code fragments *****************************************************/
+
+  /* Do something nice. */
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a[href] {
+		color: #034575;
+		text-decoration: none;
+		border-bottom: 1px solid #707070;
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
+	}
+	a:visited {
+		border-bottom-color: #BBB;
+	}
+
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
+		border: none;
+		text-decoration: none;
+		background: transparent;
+	}
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+	}
+
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
+
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
+	}
+	.caption, figcaption, caption {
+		font-style: italic;
+		font-size: 90%;
+	}
+	.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > .figure, dd > figure { margin-left: -2em }
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .assertion, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	.issue,
+	.note,
+	.example,
+	.advisement,
+	.assertion,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue::before, .issue > .marker {
+		text-transform: uppercase;
+		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
+	}
+	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: example;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		text-transform: uppercase;
+		color: #827017;
+		min-width: 7.5em;
+		display: block;
+	}
+	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
+
+/** Non-normative Note ********************************************************/
+
+	.note {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Assertion Box *************************************************************/
+	/*  for assertions in algorithms */
+
+	.assertion {
+		border-color: #AAA;
+		background: #EEE;
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+	}
+	strong.advisement {
+		display: block;
+		text-align: center;
+	}
+	.advisement > .marker {
+		color: #B35F00;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details {
+		display: block;
+	}
+	summary {
+		font-weight: bolder;
+	}
+
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
+		border-radius: 1em;
+	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
 }
-figure.sidefigure {
-  float: right;
-  width: 50%;
-  margin: 0 0 0.5em 0.5em
-}
-figure pre {
-  text-align: left;
-  display: table;
-  margin: 1em auto;
-}
-figure table {
-  margin: auto;
-}
-figure img, figure object {
-  display: block;
-  margin: auto;
-  max-width: 100%
-}
-figcaption {
-  counter-increment: figure;
-  font-size: 90%;
-  font-style: italic;
-  text-align: center;
-}
-figcaption::before {
-  content: "Figure " counter(figure) ". ";
-  font-weight: bold;
-}
-dd figure { margin-left: -2em; }
+
+	details.annoying-warning:not([open]) > summary {
+		text-align: center;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.def {
+		/* inherits .def box styling, see above */
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	table.def td,
+	table.def th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.def th {
+		font-style: italic;
+		font-weight: normal;
+		padding-left: 1em;
+		width: 3em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
+		padding-top: 0.6em;
+	}
+	table.def           td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Data tables (and properly marked-up index tables) *************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+	*/
+
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	table.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
+		border-bottom: 2px solid;
+	}
+
+	table.data colgroup,
+	table.index colgroup {
+		border-left: 2px solid;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
+	}
+
+	table.complex.data th,
+	table.complex.data td {
+		border: 1px solid silver;
+		text-align: center;
+	}
+
+	table.data.longlastcol td:last-child,
+	table.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	table.data img {
+		vertical-align: middle;
+	}
 
 
-/* Definition tables */
+/*
+Alternate table alignment rules
 
-table.definition {
-  border-spacing: 0;
-  padding: 0 1em 0.5em;
-  width: 100%;
-  table-layout: fixed;
-  margin: 1.2em 0;
-}
-table.definition td, table.definition th {
-  padding: 0.5em;
-  vertical-align: baseline;
-  border-bottom: 1px solid #bbd7e9;
-}
-table.definition th:first-child {
-  font-style: italic;
-  font-weight: normal;
-  text-align: left;
-  width: 8.3em;
-  padding-left: 1em;
-}
-table.definition > tbody > tr:last-child > th,
-table.definition > tbody > tr:last-child > td {
-  border-bottom: none;
-}
-table.definition tr:first-child > th,
-table.definition tr:first-child > td {
-  padding-top: 1em;
-}
-/* Footnotes at the bottom of a definition table */
-table.definition td.footnote {
-  font-style: normal;
-  padding-top: .6em;
-  width: auto;
-}
-table.definition td.footnote::before {
-  content: " ";
-  display: block;
-  height: 0.6em;
-  width: 4em;
-  border-top: thin solid;
-}
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
 
 
-/* IDL fragments */
+/** Table of Contents *********************************************************/
 
-pre.idl {
-  padding: .5em 1em;
-  margin: 1.2em 0;
-}
-pre.idl :link, pre.idl :visited {
-  color:inherit;
-  background:transparent;
-}
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
+	}
+	.toc a:visited {
+		border-color: #054572;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
 
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
 
-/* Data tables */
-/* Comes in plain, long, complex, or define varieties */
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li li { font-size:   85%;    }
 
-.data {
-  margin: 1em auto;
-  border-collapse: collapse;
-  width: 100%;
-  border: hidden;
-}
-.data {
-  text-align: center;
-  width: auto;
-}
-.data caption {
-  width: 100%;
-}
-.data td, .data th {
-  padding: 0.5em;
-  border-width: 1px;
-  border-color: silver;
-  border-top-style: solid;
-}
-.data thead td:empty {
-  padding: 0;
-  border: 0;
-}
-.data thead th[scope="row"] {
-  text-align: right;
-  color: inherit;
-}
-.data thead,
-.data tbody {
-  color: inherit;
-  border-bottom: 2px solid;
-}
-.data colgroup {
-  border-left: 2px solid;
-}
-.data tbody th:first-child,
-.data tbody td[scope="row"]:first-child {
-  text-align: right;
-  color: inherit;
-  border-right: 2px solid;
-  border-top: 1px solid silver;
-  padding-right: 1em;
-}
-.data.define td:last-child {
-  text-align: left;
-}
-.data tbody th[rowspan],
-.data tbody td[rowspan] {
-  border-left: 1px solid silver;
-}
-.data tbody th[rowspan]:first-child,
-.data tbody td[rowspan]:first-child {
-  border-left: 0;
-  border-right: 1px solid silver;
-}
-.data.complex th,
-.data.complex td {
-  border: 1px solid silver;
-}
-.data td.long {
- vertical-align: baseline;
- text-align: left;
-}
-.data img {
-  vertical-align: middle;
-}
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
 
+	/* Section numbers in a column of their own */
+	.toc .secno {
+		float: left;
+		width: 4rem;
+		white-space: nowrap;
+	}
+	.toc > li li li li .secno {
+		font-size: 85%;
+	}
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
 
-/* Switch/case <dl>s */
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
 
-dl.switch {
- padding-left: 2em;
-}
-dl.switch > dt {
- text-indent: -1.5em;
-}
-dl.switch > dt:before {
- content: '↪';
- padding: 0 0.5em 0 0;
- display: inline-block;
- width: 1em;
- text-align: right;
- line-height: 0.5em;
-}
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	.toc li {
+		clear: both;
+	}
 
 
-/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
-.atrisk::before {
- position: absolute;
- margin-left: -5em;
- margin-top: -2px;
- padding: 4px;
- border: 1px solid;
- content: 'At risk';
- font-size: small;
- background-color: white;
- color: gray;
- border-radius: 1em;
- text-align: center;
-}
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+		}
+	}
+
+/** Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.index {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.index td,
+	table.index th {
+		padding: 0.4em;
+	}
+
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
+	}
+
+	/* The link in the first column in the property table (formerly a TD) */
+	table.index th:first-child a {
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		/* Pages have their own margins. */
+		html {
+			margin: 0;
+		}
+		/* Serif for print. */
+		body {
+			font-family: serif;
+		}
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+/******************************************************************************/
+/*                                    Legacy                                  */
+/******************************************************************************/
+
+	/* This rule is inherited from past style sheets. No idea what it's for. */
+	.hide { display: none }
 
 
-/* Obsoletion notice */
-details.annoying-warning[open] {
-  background: #fdd;
-  color: red;
-  font-weight: bold;
-  text-align: center;
-  padding: .5em;
-  border: thick solid red;
-  border-radius: 1em;
-  position: fixed;
-  left: 1em;
-  right: 1em;
-  bottom: 1em;
-  z-index: 1000;
-}
-details.annoying-warning:not([open]) > summary {
-  background: #fdd;
-  color: red;
-  font-weight: bold;
-  text-align: center;
-  padding: .5em;
-}
 
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
 
-/* Examples */
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
 
-.example {
-  counter-increment: exampleno;
-}
-.example::before {
-  content: "Example";
-  content: "Example " counter(exampleno);
-  min-width: 7.5em;
-  text-transform: uppercase;
-  display: block;
-}
-.illegal-example::before {
-  content: "Invalid Example";
-  content: "Invalid Example" counter(exampleno);
-}
-.example, .illegal-example, .html, .illegal-html, .xml, .illegal-xml {
-  padding: 0.5em;
-  margin: 1em 0;
-  position: relative;
-  clear: both;
-}
-pre.example, pre.illegal-example, pre.html,
-pre.illegal-html, pre.xml, pre.illegal-xml {
-  padding-top: 1.5em;
-}
-.illegal-example { color: red; }
-.illegal-example p { color: black; }
-.html { color: #600; }
-.illegal-html { color: red; }
-.illegal-html p { color: black; }
-.xml { color: #600; }
-.illegal-xml { color: red; }
-.illegal-xml p { color: black; }
-code.css { font-family: inherit; font-size: 100% }
-code.html { color: #600 } /* inline HTML */
-code.xml { color: #600 }  /* inline XML */
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-left: calc(13px + 26.5rem - 50vw);
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-left: calc(40em - 50vw) !important;
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-left: 0 !important;
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
 
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
+</style>
+  <meta content="Bikeshed version 1d4d2b1d1fc168e39cb7f99218de7951c5736ec7" name="generator">
+<style>/* style-md-lists */
 
-/* Issues */
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
 
-.issue {
-  border-color: #E05252;
-  background: #FBE9E9;
-  counter-increment: issue;
-}
-.issue:before {
-  content: "Issue " counter(issue);
-  padding-right: 1em;
-  text-transform: uppercase;
-  color: #E05252;
-}
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
 
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
 
-/* Whys */
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
 
-details.why > summary {
-  font-style: italic;
-}
-details.why[open] > summary {
-  border-bottom: 1px silver solid;
-}
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
 
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
+<style>/* style-autolinks */
 
-/* All the blocks get similarly styled */
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
 
-table.definition, pre.idl, .example, .note, details.why, .issue {
-  border: none;
-  border-left: .5em solid black;
-  border-left: .5rem solid black;
-}
-.issue, .note, .example, .why {
-  padding: .5em;
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-table.definition, pre.idl {
-  background: hsl(210, 70%, 95%);
-  border-color: hsl(210, 80%, 75%);
-}
-.example {
-  background: hsl(50, 70%, 95%);
-  border-color: hsl(50, 70%, 60%);
-}
-.example::before {
-  color: hsl(50, 70%, 60%);
-}
-.note, details.why {
-  background: hsl(120, 70%, 95%);
-  border-color: hsl(120, 70%, 60%);
-}
-.note::before {
-  color: hsl(120, 70%, 60%);
-}
-.issue {
-  background: hsl(0, 70%, 95%);
-  border-color: hsl(0, 70%, 60%);
-}
-.issue::before {
-  color: hsl(0, 70%, 60%);
-}
-span.issue, span.note {
-  padding: .1em .5em .15em;
-  border-right-width: .5em;
-  border-right-style: solid;
-}
-  </style>
-  
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
 
-  
-  <style>
-  a.logo-ricg { float: left; border-bottom: none; }
-  a.logo-w3c { float: right; border-bottom: none; }
-  p[data-fill-with="logo"] {
-    float: left;
-    width: 100%;
-  }
-  </style>
-  
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
 
-  <meta content="Bikeshed 1.0.0" name="generator">
- </head>
- 
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
 
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-railroad */
+svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path{stroke-width:3;stroke:black;fill:rgba(0,0,0,0);}svg.railroad-diagram text{font:bold 14px monospace;text-anchor:middle;}svg.railroad-diagram text.label{text-anchor:start;}svg.railroad-diagram text.comment{font:italic 12px monospace;}svg.railroad-diagram rect{stroke-width:3;stroke:black;fill:hsl(120,100%,90%);}</style>
+<style>/* style-syntax-highlighting */
+
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+        code.highlight { padding: .1em; border-radius: .3em; }
+        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+        </style>
  <body class="h-entry">
-
   <div class="head">
-  
-   <p data-fill-with="logo"><a class="logo-ricg" href="http://responsiveimages.org">
-	<img alt="Responsive Images Community Group" height="49" src="https://raw.github.com/ResponsiveImagesCG/meta/master/logo/Web/RICG_logo_small.png">
-</a>
-<a class="logo-w3c" href="http://www.w3.org/">
-	<img alt="W3C" height="48" src="http://www.w3.org/Icons/w3c_home">
-</a>
-</p>
-  
-   <h1 class="p-name no-ref" id="title">Container Queries</h1>
-  
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
-    <time class="dt-updated" datetime="2015-06-05">5 June 2015</time></span></h2>
-  
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">CSS Element Queries [Level 1]</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2017-03-02">2 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://github.com/ResponsiveImagesCG/container-queries">https://github.com/ResponsiveImagesCG/container-queries</a>
+     <dd><a class="u-url" href="https://github.com/tomhodgins/element-queries-spec">https://github.com/tomhodgins/element-queries-spec</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/tomhodgins/element-query-spec/issues/">GitHub</a>
      <dt class="editor">Editor:
-     <dd class="editor p-author h-card vcard"><span class="p-name fn">Mat Marquis</span> (<a class="p-org org" href="http://bocoup.com">Bocoup</a>)
-     <dt>Version History:
-     <dd><span><a href="https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages">Commit History</a></span>
-     <dd><span><a href="https://twitter.com/respimg_commits">Github commits on Twitter</a></span>
-     <dt>Participate:
-     <dd><span><a href="http://w3c.responsiveimages.org/">Join the Responsive Issues Community Group</a></span>
-     <dd><span><a href="http://list.responsiveimages.org/">Public Mailing List</a></span>
-     <dd><span><a href="irc://irc.w3.org:6665/#respimg">IRC: #respimg on the W3C IRC server</a></span>
-     <dd><span><a href="https://twitter.com/respimg">Twitter</a></span>
-     <dd><span><a href="https://github.com/ResponsiveImagesCG/picture-element">GitHub</a></span>
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:tomhodgins@gmail.com">Tommy Hodgins</a>
     </dl>
    </div>
-  
    <div data-fill-with="warning"></div>
-  
-   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a>
-To the extent possible under law, the editors have waived all copyright
+   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 5 June 2015,
-the editors have made this specification available under the
-<a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
+In addition, as of 2 March 2017,
+the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
-Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document.
-</p>
-  
+Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
    <hr title="Separator for header">
-</div>
-
-
+  </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-
   <div class="p-summary" data-fill-with="abstract">
-   <p>Container queries allow an author to control styling based on the size of a containing element rather than the size of the user’s viewport.</p>
-
-</div>
-
-
-  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
-
-  <div data-fill-with="status">
-   <p>
-	This is an unofficial draft.
-	It is provided for discussion only and may change at any moment.
-	Its publication here does not imply endorsement of its contents by W3C.
-	Don’t cite this document other than as work in progress.
-</p></div>
-
+   <p>Element Queries allow authors to test and query values or features of elements in an HTML document. They are used in the CSS @element rule to conditionally apply styles to a document, and in various other contexts and languages, such as HTML and JavaScript.</p>
+   <p>CSS Element Queries [Level 1] describes the mechanism and syntax of scoped styles and element queries, the responsive conditions. It also describes the meta-selectors, functions, and units that make element queries powerful.</p>
+  </div>
   <div data-fill-with="at-risk"></div>
-
-
-  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
-
-  <div data-fill-with="table-of-contents" role="navigation">
-   <ul class="toc" role="directory">
-    <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
-     <ul class="toc">
-      <li><a href="#abstract0"><span class="secno">1.1</span> <span class="content">Abstract</span></a>
-       <ul class="toc">
-        <li><a href="#mq-problems"><span class="secno">1.1.1</span> <span class="content">Limitations of Viewport-Based Media Queries ## {#mq-problems}</span></a>
-       </ul>
-      <li><a href="#when-to-use"><span class="secno">1.2</span> <span class="content">When to use Container Queries</span></a>
-      <li><a href="#usage"><span class="secno">1.3</span> <span class="content">Examples of Usage</span></a>
-     </ul>
-    <li><a href="#container-queries"><span class="secno">2</span> <span class="content">Container Queries</span></a>
-     <ul class="toc">
-      <li><a href="#syntax"><span class="secno">2.1</span> <span class="content">Syntax</span></a>
-     </ul>
-    <li><a href="#defs"><span class="secno">3</span> <span class="content">Definitions</span></a>
-    <li><a href="#acks"><span class="secno">4</span> <span class="content">Acknowledgements</span></a>
-    <li><a href="#conformance"><span class="secno"></span> <span class="content">
-Conformance</span></a>
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li>
+     <a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+     <ol class="toc">
+      <li><a href="#values"><span class="secno">1.1</span> <span class="content">Values</span></a>
+      <li><a href="#units"><span class="secno">1.2</span> <span class="content">Units</span></a>
+     </ol>
+    <li>
+     <a href="#element-queries"><span class="secno">2</span> <span class="content">Element Queries</span></a>
+     <ol class="toc">
+      <li>
+       <a href="#scoped-styles"><span class="secno">2.1</span> <span class="content">Scoped Styles</span></a>
+       <ol class="toc">
+        <li><a href="#multiple-selectors"><span class="secno">2.1.1</span> <span class="content">Multiple Selectors</span></a>
+        <li><a href="#understanding-the-scope"><span class="secno">2.1.2</span> <span class="content">Understanding the Scope</span></a>
+       </ol>
+      <li>
+       <a href="#scoped-styles-with-repsonsive-conditions"><span class="secno">2.2</span> <span class="content">Scoped Styles with Responsive Conditions</span></a>
+       <ol class="toc">
+        <li><a href="#multiple-conditions"><span class="secno">2.2.1</span> <span class="content">Multiple Conditions</span></a>
+        <li><a href="#combining-element-and-media-queries"><span class="secno">2.2.2</span> <span class="content">Combining <span class="css">@element</span> and <span class="css">@media</span> queries</span></a>
+        <li><a href="#self-referential-element-queries"><span class="secno">2.2.3</span> <span class="content">Self-Referential <span class="css">@element</span> queries</span></a>
+        <li><a href="#circular-referential-element-queries"><span class="secno">2.2.4</span> <span class="content">Circular Referential <span class="css">@element</span> queries</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#syntax"><span class="secno">3</span> <span class="content">Syntax</span></a>
+     <ol class="toc">
+      <li><a href="#evaluating-element-queries"><span class="secno">3.1</span> <span class="content">Evaluating Element Queries</span></a>
+     </ol>
+    <li>
+     <a href="#meta-selectors-in-css"><span class="secno">4</span> <span class="content">Meta-Selectors</span></a>
+     <ol class="toc">
+      <li><a href="#diagram-of-meta-selectors"><span class="secno">4.1</span> <span class="content">Diagram of <span class="css">meta-selectors</span></span></a>
+     </ol>
+    <li>
+     <a href="#responsive-conditions"><span class="secno">5</span> <span class="content">Responsive Conditions</span></a>
+     <ol class="toc">
+      <li><a href="#min-width"><span class="secno">5.1</span> <span class="content">Width</span></a>
+      <li><a href="#height"><span class="secno">5.2</span> <span class="content">Height</span></a>
+      <li><a href="#characters"><span class="secno">5.3</span> <span class="content">Characters</span></a>
+      <li><a href="#lines"><span class="secno">5.4</span> <span class="content">Lines</span></a>
+      <li><a href="#children"><span class="secno">5.5</span> <span class="content">Children</span></a>
+      <li><a href="#scroll-y"><span class="secno">5.6</span> <span class="content">Scroll-Y</span></a>
+      <li><a href="#scroll-x"><span class="secno">5.7</span> <span class="content">Scroll-X</span></a>
+      <li><a href="#aspect-ratio"><span class="secno">5.8</span> <span class="content">Aspect-Ratio</span></a>
+      <li>
+       <a href="#orientation"><span class="secno">5.9</span> <span class="content">Orientation</span></a>
+       <ol class="toc">
+        <li><a href="#portrait-orientation"><span class="secno">5.9.1</span> <span class="content">Portrait Orientation</span></a>
+        <li><a href="#square-orientation"><span class="secno">5.9.2</span> <span class="content">Square Orientation</span></a>
+        <li><a href="#landscape-orientation"><span class="secno">5.9.3</span> <span class="content">Landscape Orientation</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#css-functions"><span class="secno">6</span> <span class="content">CSS Functions</span></a>
+     <ol class="toc">
+      <li>
+       <a href="#eval"><span class="secno">6.1</span> <span class="content">eval("")</span></a>
+       <ol class="toc">
+        <li><a href="#using-js-variables-in-css"><span class="secno">6.1.1</span> <span class="content">Using JavaScript Variables in CSS</span></a>
+        <li><a href="#writing-js-in-css"><span class="secno">6.1.2</span> <span class="content">Writing JavaScript in CSS</span></a>
+        <li><a href="#using-js-functions-in-css"><span class="secno">6.1.3</span> <span class="content">Using JavaScript Functions in CSS</span></a>
+        <li><a href="#replacing-values-in-css"><span class="secno">6.1.4</span> <span class="content">Replacing Values in CSS</span></a>
+        <li><a href="#replacing-properties-in-css"><span class="secno">6.1.5</span> <span class="content">Replacing Properties in CSS</span></a>
+        <li><a href="#replacing-selectors-in-css"><span class="secno">6.1.6</span> <span class="content">Replacing Selectors in CSS</span></a>
+        <li><a href="#it-selector"><span class="secno">6.1.7</span> <span class="content"><code>$it</code> selector</span></a>
+       </ol>
+     </ol>
+    <li><a href="#element-percentage-units"><span class="secno">7</span> <span class="content">Element-percentage Units</span></a>
+    <li>
+     <a href="#examples-of-element-queries"><span class="secno">8</span> <span class="content">Examples of Scoped Styles &amp; Element Queries</span></a>
+     <ol class="toc">
+      <li><a href="#example-scoped-styles"><span class="secno">8.1</span> <span class="content">Examples of valid scoped styles</span></a>
+      <li><a href="#wrapper-free-responsive-iframe"><span class="secno">8.2</span> <span class="content">Wrapper-free responsive iframe resize</span></a>
+      <li><a href="#faking-input-empty"><span class="secno">8.3</span> <span class="content">Faking <code>input:empty</code></span></a>
+      <li><a href="#auto-expanding-textarea"><span class="secno">8.4</span> <span class="content">Auto-expanding <code>textarea</code></span></a>
+      <li><a href="#display-browser-dimensions"><span class="secno">8.5</span> <span class="content">Display Browser Dimensions</span></a>
+      <li><a href="#self-responsive-grid"><span class="secno">8.6</span> <span class="content">Self-responsive Grid</span></a>
+      <li><a href="#using-variables-as-selectors"><span class="secno">8.7</span> <span class="content">Using Variables as Selectors</span></a>
+      <li><a href="#clamped-numbers-in-CSS"><span class="secno">8.8</span> <span class="content">Clamped Numbers in CSS</span></a>
+     </ol>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
-     </ul>
-   </ul></div>
-
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li>
+     <a href="#property-index"><span class="secno"></span> <span class="content">Property Index</span></a>
+     <ol class="toc">
+      <li><a href="#element-descriptor-table"><span class="secno"></span> <span class="content"><span>@element</span> Descriptors</span></a>
+     </ol>
+   </ol>
+  </nav>
   <main>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>By default all CSS is written from the global scope (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#root-pseudo">:root</a>, or the HTML element), and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">@media</a> queries apply globally to all elements based on the conditions of the browser and media.</p>
+   <p>The idea of a scoped style is to allow CSS to view a rule, or multiple rules from the perspective of any element in the document as though it was <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#root-pseudo">:root</a>.</p>
+   <p>Just like CSS already has <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">@media</a> queries which help define styles for different media conditions, this document describes functionality for an <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-1">@element</a> query syntax to define styles that target elements more specifically with conditions based on their own properties.</p>
+   <h3 class="heading settled" data-level="1.1" id="values"><span class="secno">1.1. </span><span class="content">Values</span><a class="self-link" href="#values"></a></h3>
+   <p>Value types not defined in this specification, such as <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a>, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/mediaqueries-4/#typedef-ratio">&lt;ratio></a>, and <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a> are defined in <a data-link-type="biblio" href="#biblio-css3val">[CSS3VAL]</a>, and <a data-link-type="biblio" href="#biblio-mediaqueries-4">[MEDIAQUERIES-4]</a></p>
+   <h3 class="heading settled" data-level="1.2" id="units"><span class="secno">1.2. </span><span class="content">Units</span><a class="self-link" href="#units"></a></h3>
+   <p>The units used in element queries are the same as in other parts of CSS, as defined in <a data-link-type="biblio" href="#biblio-css3val">[CSS3VAL]</a>. For example, the pixel unit represents CSS pixels and not physical pixels.</p>
+   <p>Additionally, new <a href="#element-percentage-units">element-percentage units</a> are defined in this document which relate to an element’s own properties after styles have been applied to the document.</p>
+   <h2 class="heading settled" data-level="2" id="element-queries"><span class="secno">2. </span><span class="content">Element Queries</span><a class="self-link" href="#element-queries"></a></h2>
+   <p>An <strong>element query</strong> is a method of testing certain aspects of an element and applying styles based on whether that test is true or false.</p>
+   <p>The syntax of an element query consists of a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a>, plus an optional list of zero or more responsive conditions, followed by one or more CSS rules:</p>
+   <div class="railroad">
+    <svg class="railroad-diagram" height="81" viewBox="0 0 869 81" width="869">
+     <g transform="translate(.5 .5)">
+      <path d="M 20 31 v 20 m 10 -20 v 20 m -10 -10 h 20.5" data-type="start" data-updown="10 10"></path>
+      <path d="M40 41h10"></path>
+      <path d="M134 41h10"></path>
+      <g data-type="terminal" data-updown="11 11">
+       <path d="M50 41h0.0"></path>
+       <path d="M134.0 41h0.0"></path>
+       <rect height="22" rx="10" ry="10" width="84" x="50.0" y="30"></rect>
+       <text x="92.0" y="45"> @element</text>
+      </g>
+      <path d="M144 41h10"></path>
+      <path d="M278 41h10"></path>
+      <g data-type="non-terminal" data-updown="11 11">
+       <path d="M154 41h0.0"></path>
+       <path d="M278.0 41h0.0"></path>
+       <rect height="22" width="124" x="154.0" y="30"></rect>
+       <text x="216.0" y="45"> selector list</text>
+      </g>
+      <g data-type="choice" data-updown="21 20">
+       <path d="M288 41h0.0"></path>
+       <path d="M612.0 41h0.0"></path>
+       <path d="M288.0 41a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+       <path d="M592.0 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+       <g data-type="skip" data-updown="0 0">
+        <path d="M308.0 21h284"></path>
+       </g>
+       <path d="M288.0 41h20"></path>
+       <path d="M592.0 41h20"></path>
+       <g data-type="oneormore" data-updown="11 20">
+        <path d="M308.0 41h0.0"></path>
+        <path d="M592.0 41h0.0"></path>
+        <path d="M308.0 41h10"></path>
+        <path d="M582.0 41h10"></path>
+        <path d="M318.0 41a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
+        <path d="M582.0 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
+        <g data-type="sequence" data-updown="11 11">
+         <path d="M318.0 41h0.0"></path>
+         <path d="M582.0 41h0.0"></path>
+         <path d="M318.0 41h10"></path>
+         <path d="M372.0 41h10"></path>
+         <g data-type="terminal" data-updown="11 11">
+          <path d="M328.0 41h0.0"></path>
+          <path d="M372.0 41h0.0"></path>
+          <rect height="22" rx="10" ry="10" width="44" x="328.0" y="30"></rect>
+          <text x="350.0" y="45"> and</text>
+         </g>
+         <path d="M382.0 41h10"></path>
+         <path d="M572.0 41h10"></path>
+         <g data-type="non-terminal" data-updown="11 11">
+          <path d="M392.0 41h0.0"></path>
+          <path d="M572.0 41h0.0"></path>
+          <rect height="22" width="180" x="392.0" y="30"></rect>
+          <text x="482.0" y="45"> responsive condition</text>
+         </g>
+        </g>
+        <g data-type="skip" data-updown="0 0">
+         <path d="M318.0 61h264"></path>
+        </g>
+       </g>
+      </g>
+      <path d="M612 41h10"></path>
+      <path d="M650 41h10"></path>
+      <g data-type="terminal" data-updown="11 11">
+       <path d="M622 41h0.0"></path>
+       <path d="M650.0 41h0.0"></path>
+       <rect height="22" rx="10" ry="10" width="28" x="622.0" y="30"></rect>
+       <text x="636.0" y="45"> {</text>
+      </g>
+      <path d="M660 41h10"></path>
+      <path d="M770 41h10"></path>
+      <g data-type="non-terminal" data-updown="11 11">
+       <path d="M670 41h0.0"></path>
+       <path d="M770.0 41h0.0"></path>
+       <rect height="22" width="100" x="670.0" y="30"></rect>
+       <text x="720.0" y="45"> stylesheet</text>
+      </g>
+      <path d="M780 41h10"></path>
+      <path d="M818 41h10"></path>
+      <g data-type="terminal" data-updown="11 11">
+       <path d="M790 41h0.0"></path>
+       <path d="M818.0 41h0.0"></path>
+       <rect height="22" rx="10" ry="10" width="28" x="790.0" y="30"></rect>
+       <text x="804.0" y="45"> }</text>
+      </g>
+      <path d="M 828 41 h 20 m -10 -10 v 20 m 10 -20 v 20" data-type="end" data-updown="10 10"></path>
+     </g>
+    </svg>
+   </div>
+   <p>A scoped style will return true as long as at least one element in the document matches a selector in the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a>.</p>
+   <p>An element query is a logical expression that is either true or false. An element query is true if:</p>
+   <ul>
+    <li>at least one element in the document matches a selector in the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a> 
+    <li>all responsive conditions are true 
+   </ul>
+   <p>User agents must re-evaluate element queries in response to changes in the user environment that they’re aware of, for example resizing the browser, clicking, or scrolling, depending on which responsive conditions are being evaluated, and change the styles applied accordingly.</p>
+   <h3 class="heading settled" data-level="2.1" id="scoped-styles"><span class="secno">2.1. </span><span class="content">Scoped Styles</span><a class="self-link" href="#scoped-styles"></a></h3>
+   <p>To write a scoped style, write <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-2">@element</a>, followed by any amount of whitespace. Wrap one or more comma-separated CSS <a class="production css" data-link-type="type" href="https://www.w3.org/TR/selectors4/#ltselector">&lt;selector></a> in single (<code>'</code>) or double (<code>"</code>) quotes, followed by any amount of whitespace, and wrap one or more CSS rules in a pair of curly brackets (<code>{</code>,<code>}</code>).</p>
+   <div class="example" id="example-f4c76520">
+    <a class="self-link" href="#example-f4c76520"></a> Example scoped style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'html'</span> { ... <span class="p">}</span>
+</pre>
+   </div>
+   <h4 class="heading settled" data-level="2.1.1" id="multiple-selectors"><span class="secno">2.1.1. </span><span class="content">Multiple Selectors</span><a class="self-link" href="#multiple-selectors"></a></h4>
+   <p>You can include multiple CSS selectors in your scoped style by separating them with a comma and any amount of whitespace.</p>
+   <div class="example" id="example-142b51c9">
+    <a class="self-link" href="#example-142b51c9"></a> Comma-separated selector list 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'ul, ol'</span> { ... <span class="p">}</span>
+</pre>
+   </div>
+   <h4 class="heading settled" data-level="2.1.2" id="understanding-the-scope"><span class="secno">2.1.2. </span><span class="content">Understanding the Scope</span><a class="self-link" href="#understanding-the-scope"></a></h4>
+   <p>Any element on the page that matches a selector will apply the rules contained inside its scope to the page. The following examples will illustrate how the scope applies.</p>
+   <p>If we have two <code>div</code> elements in our HTML:</p>
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">div</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">demo</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+</pre>
+   <div class="example" id="example-6857413d">
+    <a class="self-link" href="#example-6857413d"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div'</span> <span class="p">{</span>
+  <span class="nt">div </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+    <p>In this example, because there are two <code>div</code> elements, both will match our scope and apply a rule saying all <code>div</code> elements have a green background.</p>
+   </div>
+   <div class="example" id="example-60bd79b7">
+    <a class="self-link" href="#example-60bd79b7"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.demo'</span> <span class="p">{</span>
+  <span class="nt">div </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+    <p>In this example we have one element in our HTML with a class of <code>.demo</code>. Because of this, the rule applying to all <code>div</code> elements applies to both of the <code>div</code> elements in our HTML turning their background green.</p>
+   </div>
+   <div class="example" id="example-56ac8c36">
+    <a class="self-link" href="#example-56ac8c36"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.demo'</span> <span class="p">{</span>
+  <span class="nt">.demo </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+    <p>In this example we have one element in our HTML with a class of <code>.demo</code>. Because of this, the rule applying to any elements with a class of <code>.demo</code> applies and turns the background of our <code>.demo</code> element green, leaving the other <code>div</code> untouched.</p>
+   </div>
+   <div class="example" id="example-77910dd8">
+    <a class="self-link" href="#example-77910dd8"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div'</span> <span class="p">{</span>
+  <span class="nt">.demo </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+    <p>In this example, because there are two <code>div</code> elements, both will match our scope and apply a rule saying any element with a class of <code>.demo</code> will have a green background. This makes one of our <code>div</code> elements green and leaves the other untouched.</p>
+   </div>
+   <div class="example" id="example-9174342c">
+    <a class="self-link" href="#example-9174342c"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'select'</span> <span class="p">{</span>
+  <span class="nt">.demo </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+    <p>In this example we did not have any <code>select</code> elements in our HTML, so nothing will match our scope and no styles will be applied, leaving both of our <code>div</code> elements untouched.</p>
+   </div>
+   <p>It is possible for an element to match more than one <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-3">@element</a> query.</p>
+   <h3 class="heading settled" data-level="2.2" id="scoped-styles-with-repsonsive-conditions"><span class="secno">2.2. </span><span class="content">Scoped Styles with Responsive Conditions</span><a class="self-link" href="#scoped-styles-with-repsonsive-conditions"></a></h3>
+   <p>An element query is a scoped style with one or more responsive conditions added.</p>
+   <p>The following global CSS and scoped style are equivalent.</p>
+   <div class="example" id="example-0e633278">
+    <a class="self-link" href="#example-0e633278"></a> Example of global CSS 
+<pre class="language-css highlight"><span class="nt">body </span><span class="p">{</span>
+  <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+<span class="p">}</span>
+</pre>
+   </div>
+   <div class="example" id="example-cf76a911">
+    <a class="self-link" href="#example-cf76a911"></a> Example scoped style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'html'</span> <span class="p">{</span>
+  <span class="nt">body </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+   </div>
+   <p>In both cases, as long as there is a <code>body</code> element inside of our <code>html</code>, it will have a lime background.</p>
+   <p>We can also add a responsive conditions to our scoped styles. To do this, write <code>and </code> followed by a responsive condition and value, separated by a colon (<code>:</code>) and wrapped in brackets (<code>(</code>,<code>)</code>).</p>
+   <div class="example" id="example-fbb0cdc4">
+    <a class="self-link" href="#example-fbb0cdc4"></a> Example Element Query with Responsive Condition 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'html'</span> and <span class="p">(</span>min-width<span class="nt">: 500px) </span><span class="p">{</span>
+  body {
+    background: lime;
+  }
+}
+</pre>
+   </div>
+   <p>In this case, our element query is equivalent to the following media query, but not every element query will be able to be expressed as a media query.</p>
+   <div class="example" id="example-4f764618">
+    <a class="self-link" href="#example-4f764618"></a> Example media query with responsive condition 
+<pre class="language-css highlight"><span class="n">@media</span> <span class="p">(</span>min-width<span class="nt">: 500px) </span><span class="p">{</span>
+  body {
+    background: lime;
+  }
+}
+</pre>
+   </div>
+   <h4 class="heading settled" data-level="2.2.1" id="multiple-conditions"><span class="secno">2.2.1. </span><span class="content">Multiple Conditions</span><a class="self-link" href="#multiple-conditions"></a></h4>
+   <p>You can add more than one responsive conditions to your element query. For this, include another <code>and</code>, followed by another responsive condition as before.</p>
+   <div class="example" id="example-7f252543">
+    <a class="self-link" href="#example-7f252543"></a> Element query with multiple responsive conditions 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'html'</span> and <span class="p">(</span>min-width<span class="nt">: 500px) and (max-width: 1000px) </span><span class="p">{</span>
+  body {
+    background: lime;
+  }
+}
+</pre>
+   </div>
+   <p>Which in this case can be compared to the equivalent media query.</p>
+   <div class="example" id="example-4b18a2da">
+    <a class="self-link" href="#example-4b18a2da"></a> Media query with multiple responsive conditions 
+<pre class="language-css highlight"><span class="n">@media</span> <span class="p">(</span>min-width<span class="nt">: 500px) and (max-width: 1000px) </span><span class="p">{</span>
+  body {
+    background: lime;
+  }
+}
+</pre>
+   </div>
+   <p>In both cases when our <code>html</code> is between the sizes of <code>500px</code> and <code>1000px</code>, our <code>body</code> will have a lime background.</p>
+   <h4 class="heading settled" data-level="2.2.2" id="combining-element-and-media-queries"><span class="secno">2.2.2. </span><span class="content">Combining <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-4">@element</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">@media</a> queries</span><a class="self-link" href="#combining-element-and-media-queries"></a></h4>
+   <p>It’s possible to combine the use of scoped styles or element queries with media queries. Most of the time we combine them we want to include the media query on the inside of the element query. This will mean any time the element query is true, that media query will be visible to the browser and apply.</p>
+   <div class="example" id="example-f47b1458">
+    <a class="self-link" href="#example-f47b1458"></a> Nesting a media query inside an element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'#headline'</span> and <span class="p">(</span>min-characters<span class="nt">: 20) </span><span class="p">{</span>
+  <span class="n">@media</span> print <span class="p">{</span>
+    <span class="nt">#headline </span><span class="p">{</span>
+      <span class="k">border</span><span class="p">:</span> <span class="m">1</span><span class="l">px</span> solid black<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+   </div>
+   <p>In this example, if the element with an ID of <code>#headline</code> has over 20 characters, it will display in print media with a thin black border.</p>
+   <h4 class="heading settled" data-level="2.2.3" id="self-referential-element-queries"><span class="secno">2.2.3. </span><span class="content">Self-Referential <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-5">@element</a> queries</span><a class="self-link" href="#self-referential-element-queries"></a></h4>
+   <p>With element queries comes the new possibility that the rules you are applying when your responsive conditions are met will conflict with the responsive condition in your element query. In this situation we should not attempt to detect or handle these cases by ignoring certain styles, or checking whether any of the rules affect the validity of the responsive condition. It is best to apply the rule naïvely and allow the conflict to occur.</p>
+   <p class="note" role="note">Note, The responsibility lies with the author to write <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-6">@element</a> queries which can be interpreted logically.</p>
+   <div class="example" id="example-e9755d1c">
+    <a class="self-link" href="#example-e9755d1c"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min<span class="nt">‐width: 300px) </span><span class="p">{</span>
+  $this {
+    width: 200px;
+  }
+}
+</pre>
+   </div>
+   <p>In this example the query will only apply to elements with a class of <code>.widget</code> that are equal or wider than <code>300px</code>, and the rule sets a width on the same element which would make the rule no longer apply. Rather than trying to detect or intercept this behaviour and prevent it from happening, when the <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-7">@element</a> query applies to the document it will set the width to <code>200px</code>.</p>
+   <h4 class="heading settled" data-level="2.2.4" id="circular-referential-element-queries"><span class="secno">2.2.4. </span><span class="content">Circular Referential <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-8">@element</a> queries</span><a class="self-link" href="#circular-referential-element-queries"></a></h4>
+   <p>Another new possibility with element queries is having two or more queries that apply styles that match each others responsive condition. Just as with a self-referential <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-9">@element</a> query, we should not try to detect or ignore styles in this situation, and instead should compute the <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-10">@element</a> queries in the order they appear and apply the rules using normal CSS specificity.</p>
+   <div class="example" id="example-b427f96a">
+    <a class="self-link" href="#example-b427f96a"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min<span class="nt">‐width: 400px) </span><span class="p">{</span>
+  $this {
+    width: 200px;
+  }
+}
+@element '.widget' and (max‐width: 300px) {
+  $this {
+    width: 500px;
+  }
+}
+</pre>
+   </div>
+   <p>In this example any element with a class of <code>.widget</code> that is equal to <code>400px</code> or wider will apply a rule setting the width of the same element to <code>200px</code>, which makes the following <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-11">@element</a> query valid. The second query sets a width of <code>500px</code> on the same element. In this case, even though the element now matches the responsive condition of the first query again, rather than get stuck in an infinite loop, we consider evaluation complete.</p>
+   <h2 class="heading settled" data-level="3" id="syntax"><span class="secno">3. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h2>
+   <p>Informal descriptions of the element query syntax appear in the prose and railroad diagrams of the previous sections. The formal element query syntax is described in this section, with the rule/property grammar syntax defined in <a data-link-type="biblio" href="#biblio-css3syn">[CSS3SYN]</a> and <a data-link-type="biblio" href="#biblio-css3val">[CSS3VAL]</a>.</p>
+<pre><dfn class="dfn-paneled" data-dfn-type="at-rule" data-export="" id="at-ruledef-element">@element</dfn> = @element <a class="production" data-link-type="type" href="#typedef-eq-prelude" id="ref-for-typedef-eq-prelude-1">&lt;eq-prelude></a> { <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">&lt;stylesheet></a> }
+
+<dfn class="dfn-paneled" data-dfn-type="type" data-export="" id="typedef-eq-prelude">&lt;eq-prelude></dfn> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a> | <a class="production" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a> <a class="production" data-link-type="type" href="#typedef-eq-condition" id="ref-for-typedef-eq-condition-1">&lt;eq-condition></a>*
+
+<dfn class="dfn-paneled" data-dfn-type="type" data-export="" id="typedef-eq-condition">&lt;eq-condition></dfn> = and ( <a class="production" data-link-type="type" href="#typedef-eq-name" id="ref-for-typedef-eq-name-1">&lt;eq-name></a> : <a class="production" data-link-type="type" href="#typedef-eq-value" id="ref-for-typedef-eq-value-1">&lt;eq-value></a> )
+
+<dfn class="dfn-paneled" data-dfn-type="type" data-export="" id="typedef-eq-name">&lt;eq-name></dfn> = min-width | max-width | min-height
+  | max-height | min-characters | max-characters
+  | min-lines | max-lines | min-children
+  | max-children | min-scroll-y | max-scroll-y
+  | min-scroll-x | max-scroll-x | orientation
+  | min-aspect-ratio | max-aspect-ratio
+
+<dfn class="dfn-paneled" data-dfn-type="type" data-export="" id="typedef-eq-value">&lt;eq-value></dfn> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a> | <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a> | <a class="production" data-link-type="type" href="https://drafts.csswg.org/mediaqueries-4/#typedef-ratio">&lt;ratio></a> | <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>
+
+<dfn class="dfn-paneled" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors">meta-selectors</dfn> = $this | $parent | $prev | $next | $it
+
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="eq-unit">eq-unit</dfn> = ew | eh | emin | emax
+
+<dfn class="dfn-paneled" data-dfn-type="function" data-export="" data-lt="eval()" id="funcdef-eval">eval("")</dfn> = eval(" <span class="css">javascript-code</span> ")
+</pre>
+   <h3 class="heading settled" data-level="3.1" id="evaluating-element-queries"><span class="secno">3.1. </span><span class="content">Evaluating Element Queries</span><a class="self-link" href="#evaluating-element-queries"></a></h3>
+   <p>Each <a class="production css" data-link-type="type" href="#typedef-eq-condition" id="ref-for-typedef-eq-condition-2">&lt;eq-condition></a> is associated with a boolean result, the same as the result of evaluating the specified responsive condition.</p>
+   <p>If the result of any responsive condition is used in any context that expects a two-valued boolean, "unknown" must be converted to "false".</p>
+   <p class="note" role="note">Note: This means that, for example, when an element query is used in an @element rule, if it resolves to "unknown" it is treated as "false" and fails to match.</p>
+   <h2 class="heading settled" data-level="4" id="meta-selectors-in-css"><span class="secno">4. </span><span class="content">Meta-Selectors</span><a class="self-link" href="#meta-selectors-in-css"></a></h2>
+   <p>With element queries comes the need to target elements based on the scope we have defined. There are a number of new selectors that help target elements relative to the scope we have defined. These new selectors only work inside a scoped style or element query and are called <a class="css" data-link-type="maybe" href="#selectordef-meta-selectors" id="ref-for-selectordef-meta-selectors-1">meta-selectors</a>.</p>
+   <h3 class="heading settled" data-level="4.1" id="diagram-of-meta-selectors"><span class="secno">4.1. </span><span class="content">Diagram of <a class="css" data-link-type="maybe" href="#selectordef-meta-selectors" id="ref-for-selectordef-meta-selectors-2">meta-selectors</a></span><a class="self-link" href="#diagram-of-meta-selectors"></a></h3>
+   <p>Here is a diagram showing the relationship between the meta-selectors. The <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-parent" id="ref-for-selectordef-meta-selectors-parent-1">$parent</a> is the parent element of <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-1">$this</a>, and <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-prev" id="ref-for-selectordef-meta-selectors-prev-1">$prev</a> and <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-next" id="ref-for-selectordef-meta-selectors-next-1">$next</a> represent the adjacent siblings to <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-2">$this</a>.</p>
+<pre style="text-align:center;"><a data-link-type="selector" href="#selectordef-meta-selectors-parent" id="ref-for-selectordef-meta-selectors-parent-2">$parent</a>
+↑
+<a data-link-type="selector" href="#selectordef-meta-selectors-prev" id="ref-for-selectordef-meta-selectors-prev-2">$prev</a> ← <a data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-3">$this</a> → <a data-link-type="selector" href="#selectordef-meta-selectors-next" id="ref-for-selectordef-meta-selectors-next-2">$next</a>
+</pre>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="meta-selectors" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors-this">$this</dfn> 
+    <dd>
+      The <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-4">$this</a> meta-selector refers each element at the root of our scoped style when it matches the responsive condition. 
+     <div class="example" id="example-efd7d215">
+      <a class="self-link" href="#example-efd7d215"></a> Example of <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-5">$this</a> meta-selector 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min-width<span class="nt">: 200px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+      <p>In this case, any element with a class of <code>.widget</code> that is <code>200px</code> or wider will have a green background.</p>
+     </div>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="meta-selectors" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors-parent">$parent</dfn> 
+    <dd>
+      The <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-parent" id="ref-for-selectordef-meta-selectors-parent-3">$parent</a> meta-selector refers to the element containing the element(s) in the scope of our scoped style or element query. 
+     <div class="example" id="example-9cc20eb3">
+      <a class="self-link" href="#example-9cc20eb3"></a> Example of <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-parent" id="ref-for-selectordef-meta-selectors-parent-4">$parent</a> meta-selector 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min-width<span class="nt">: 200px) </span><span class="p">{</span>
+  $parent {
+    background: lime;
+  }
+}
+</pre>
+      <p>In this case, any element containing an element with a class of <code>.widget</code> that is equal or wider than <code>200px</code> will have a green background.</p>
+     </div>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="meta-selectors" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors-prev">$prev</dfn> 
+    <dd>
+      The <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-prev" id="ref-for-selectordef-meta-selectors-prev-3">$prev</a> meta-selector refers to the sibling directly above the element at the root of our scoped style or element query. 
+     <div class="example" id="example-c467d3b0">
+      <a class="self-link" href="#example-c467d3b0"></a> Example of <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-prev" id="ref-for-selectordef-meta-selectors-prev-4">$prev</a> meta-selector 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$prev </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case, any sibling coming directly before any element with a class of <code>.widget</code> will have a green background.</p>
+     </div>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="meta-selectors" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors-next">$next</dfn> 
+    <dd>
+      The <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-next" id="ref-for-selectordef-meta-selectors-next-3">$next</a> meta-selector refers to the sibling directly below the element at the root of our scoped style or element query. 
+     <div class="example" id="example-f955cb3d">
+      <a class="self-link" href="#example-f955cb3d"></a> Example of <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-next" id="ref-for-selectordef-meta-selectors-next-4">$next</a> meta-selector 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$next </span><span class="p">{</span>
+    <span class="k">background</span><span class="p">:</span> lime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case, any sibling coming directly after any element with a class of <code>.widget</code> will have a green background.</p>
+     </div>
+     <p class="note" role="note">Note, the <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-next" id="ref-for-selectordef-meta-selectors-next-5">$next</a> is similar to the selector: <code>$this + *</code></p>
+   </dl>
+   <h2 class="heading settled" data-level="5" id="responsive-conditions"><span class="secno">5. </span><span class="content">Responsive Conditions</span><a class="self-link" href="#responsive-conditions"></a></h2>
+   <p>All responsive conditions for <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-12">@element</a> queries are formatted as a condition name and value, separated by a colon (<code>:</code>) character, surrounded by brackets (<code>()</code>).</p>
+   <div class="railroad">
+    <svg class="railroad-diagram" height="81" viewBox="0 0 581 81" width="581">
+     <g transform="translate(.5 .5)">
+      <path d="M 20 31 v 20 m 10 -20 v 20 m -10 -10 h 20.5" data-type="start" data-updown="10 10"></path>
+      <g data-type="choice" data-updown="21 20">
+       <path d="M40 41h0.0"></path>
+       <path d="M540.0 41h0.0"></path>
+       <path d="M40.0 41a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+       <path d="M520.0 21a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+       <g data-type="skip" data-updown="0 0">
+        <path d="M60.0 21h460"></path>
+       </g>
+       <path d="M40.0 41h20"></path>
+       <path d="M520.0 41h20"></path>
+       <g data-type="oneormore" data-updown="11 20">
+        <path d="M60.0 41h0.0"></path>
+        <path d="M520.0 41h0.0"></path>
+        <path d="M60.0 41h10"></path>
+        <path d="M510.0 41h10"></path>
+        <path d="M70.0 41a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
+        <path d="M510.0 61a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
+        <g data-type="sequence" data-updown="11 11">
+         <path d="M70.0 41h0.0"></path>
+         <path d="M510.0 41h0.0"></path>
+         <path d="M70.0 41h10"></path>
+         <path d="M124.0 41h10"></path>
+         <g data-type="terminal" data-updown="11 11">
+          <path d="M80.0 41h0.0"></path>
+          <path d="M124.0 41h0.0"></path>
+          <rect height="22" rx="10" ry="10" width="44" x="80.0" y="30"></rect>
+          <text x="102.0" y="45"> and</text>
+         </g>
+         <path d="M134.0 41h10"></path>
+         <path d="M172.0 41h10"></path>
+         <g data-type="terminal" data-updown="11 11">
+          <path d="M144.0 41h0.0"></path>
+          <path d="M172.0 41h0.0"></path>
+          <rect height="22" rx="10" ry="10" width="28" x="144.0" y="30"></rect>
+          <text x="158.0" y="45"> (</text>
+         </g>
+         <path d="M182.0 41h10"></path>
+         <path d="M324.0 41h10"></path>
+         <g data-type="non-terminal" data-updown="11 11">
+          <path d="M192.0 41h0.0"></path>
+          <path d="M324.0 41h0.0"></path>
+          <rect height="22" width="132" x="192.0" y="30"></rect>
+          <text x="258.0" y="45"> condition name</text>
+         </g>
+         <path d="M334.0 41h10"></path>
+         <path d="M372.0 41h10"></path>
+         <g data-type="terminal" data-updown="11 11">
+          <path d="M344.0 41h0.0"></path>
+          <path d="M372.0 41h0.0"></path>
+          <rect height="22" rx="10" ry="10" width="28" x="344.0" y="30"></rect>
+          <text x="358.0" y="45"> :</text>
+         </g>
+         <path d="M382.0 41h10"></path>
+         <path d="M452.0 41h10"></path>
+         <g data-type="non-terminal" data-updown="11 11">
+          <path d="M392.0 41h0.0"></path>
+          <path d="M452.0 41h0.0"></path>
+          <rect height="22" width="60" x="392.0" y="30"></rect>
+          <text x="422.0" y="45"> value</text>
+         </g>
+         <path d="M462.0 41h10"></path>
+         <path d="M500.0 41h10"></path>
+         <g data-type="terminal" data-updown="11 11">
+          <path d="M472.0 41h0.0"></path>
+          <path d="M500.0 41h0.0"></path>
+          <rect height="22" rx="10" ry="10" width="28" x="472.0" y="30"></rect>
+          <text x="486.0" y="45"> )</text>
+         </g>
+        </g>
+        <g data-type="skip" data-updown="0 0">
+         <path d="M70.0 61h440"></path>
+        </g>
+       </g>
+      </g>
+      <path d="M 540 41 h 20 m -10 -10 v 20 m 10 -20 v 20" data-type="end" data-updown="10 10"></path>
+     </g>
+    </svg>
+   </div>
+   <p>The following examples are all valid as <a class="production css" data-link-type="type" href="#typedef-eq-condition" id="ref-for-typedef-eq-condition-3">&lt;eq-condition></a>:</p>
+   <div class="example" id="example-806ba5e6">
+    <a class="self-link" href="#example-806ba5e6"></a> 
+<pre class="language-css highlight">(min-width: 500px)
+</pre>
+   </div>
+   <div class="example" id="example-6b30b57c">
+    <a class="self-link" href="#example-6b30b57c"></a> 
+<pre class="language-css highlight">(min-aspect-ratio: 16/9)
+</pre>
+   </div>
+   <div class="example" id="example-0771a4ec">
+    <a class="self-link" href="#example-0771a4ec"></a> 
+<pre class="language-css highlight">(orientation: landscape)
+</pre>
+   </div>
+   <h3 class="heading settled" data-level="5.1" id="min-width"><span class="secno">5.1. </span><span class="content">Width</span><a class="self-link" href="#min-width"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-width">width</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-13">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-width" id="ref-for-descdef-element-width-1">min-width</a> responsive condition applies to any scoped element that has greater or equal (<code>>=</code>) width to the specified value.</p>
+   <div class="example" id="example-e7b50074">
+    <a class="self-link" href="#example-e7b50074"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-width" id="ref-for-descdef-element-width-2">min-width</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min-width<span class="nt">: 200px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that is at least <code>200px</code> or wider will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-width" id="ref-for-descdef-element-width-3">max-width</a> responsive condition applies to any scoped element that has lesser or equal (<code>&lt;=</code>) width to the specified value.</p>
+   <div class="example" id="example-cc25b3e5">
+    <a class="self-link" href="#example-cc25b3e5"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-width" id="ref-for-descdef-element-width-4">max-width</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>max-width<span class="nt">: 200) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that <code>200px</code> or narrower will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.2" id="height"><span class="secno">5.2. </span><span class="content">Height</span><a class="self-link" href="#height"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-height">height</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-14">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-height" id="ref-for-descdef-element-height-1">min-height</a> responsive condition applies to any scoped element that has greater or equal (<code>>=</code>) height to the specified value.</p>
+   <div class="example" id="example-31d6cfca">
+    <a class="self-link" href="#example-31d6cfca"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-height" id="ref-for-descdef-element-height-2">min-height</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min-height<span class="nt">: 50px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that is at least <code>50px</code> or taller will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-height" id="ref-for-descdef-element-height-3">max-height</a> responsive condition applies to any scoped element that has lesser or equal (<code>&lt;=</code>) height to the specified value.</p>
+   <div class="example" id="example-04650ccd">
+    <a class="self-link" href="#example-04650ccd"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-height" id="ref-for-descdef-element-height-4">max-height</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>max-height<span class="nt">: 50px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that is at least <code>50px</code> or shorter will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.3" id="characters"><span class="secno">5.3. </span><span class="content">Characters</span><a class="self-link" href="#characters"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-characters">characters</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-15">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-characters" id="ref-for-descdef-element-characters-1">min-characters</a> responsive condition applies to any scoped element that contains a greater or equal (<code>>=</code>) number of characters.</p>
+   <div class="example" id="example-e35566e6">
+    <a class="self-link" href="#example-e35566e6"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-characters" id="ref-for-descdef-element-characters-2">min-characters</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'input'</span> and <span class="p">(</span>min-characters<span class="nt">: 5) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any input with 5 or more characters will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-characters" id="ref-for-descdef-element-characters-3">max-characters</a> responsive condition applies to any scoped element that contains lesser or equal (<code>&lt;=</code>) number of characters specified.</p>
+   <div class="example" id="example-912b420b">
+    <a class="self-link" href="#example-912b420b"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-characters" id="ref-for-descdef-element-characters-4">max-characters</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'input'</span> and <span class="p">(</span>max-characters<span class="nt">: 5) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any input with 5 or fewer characters will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.4" id="lines"><span class="secno">5.4. </span><span class="content">Lines</span><a class="self-link" href="#lines"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-lines">lines</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-16">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-lines" id="ref-for-descdef-element-lines-1">min-lines</a> responsive condition applies to any scoped element that contains greater or equal (<code>>=</code>) number of specified lines of text.</p>
+   <div class="example" id="example-67f15d26">
+    <a class="self-link" href="#example-67f15d26"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-lines" id="ref-for-descdef-element-lines-2">min-lines</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'textarea'</span> and <span class="p">(</span>min-lines<span class="nt">: 3) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any textarea with 3 or more lines will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-lines" id="ref-for-descdef-element-lines-3">max-lines</a> responsive condition applies to any scoped element that contains lesser or equal (<code>&lt;=</code>) number of specified lines of text.</p>
+   <div class="example" id="example-84774634">
+    <a class="self-link" href="#example-84774634"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-lines" id="ref-for-descdef-element-lines-4">max-lines</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'textarea'</span> and <span class="p">(</span>max-lines<span class="nt">: 3) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any textarea with 3 or fewer lines will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.5" id="children"><span class="secno">5.5. </span><span class="content">Children</span><a class="self-link" href="#children"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-children">children</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-17">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-children" id="ref-for-descdef-element-children-1">min-children</a> responsive condition applies to any scoped element that contains greater or equal (<code>>=</code>) number of child elements specified.</p>
+   <div class="example" id="example-c4b5f634">
+    <a class="self-link" href="#example-c4b5f634"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-children" id="ref-for-descdef-element-children-2">min-children</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.social-icons'</span> and <span class="p">(</span>min-children<span class="nt">: 5) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.social-icons</code> that contains more 5 or more direct descendants will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-children" id="ref-for-descdef-element-children-3">max-children</a> responsive condition applies to any scoped element that contains lesser or equal (<code>&lt;=</code>) number of child elements specified.</p>
+   <div class="example" id="example-2d81e055">
+    <a class="self-link" href="#example-2d81e055"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-children" id="ref-for-descdef-element-children-4">max-children</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.social-icons'</span> and <span class="p">(</span>max-children<span class="nt">: 5) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.social-icons</code> that contains more 5 or fewer direct descendants will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.6" id="scroll-y"><span class="secno">5.6. </span><span class="content">Scroll-Y</span><a class="self-link" href="#scroll-y"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-scroll-y">scroll-y</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-18">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-y" id="ref-for-descdef-element-scroll-y-1">min-scroll-y</a> responsive condition applies to any scoped element that has scrolled a greater or equal (<code>>=</code>) amount to the value specified in a vertical direction.</p>
+   <div class="example" id="example-2a76b37c">
+    <a class="self-link" href="#example-2a76b37c"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-y" id="ref-for-descdef-element-scroll-y-2">min-scroll-y</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.feed'</span> and <span class="p">(</span>min-scroll-y<span class="nt">: 100px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.feed</code> that has scrolled <code>100px</code> or more vertical will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-y" id="ref-for-descdef-element-scroll-y-3">max-scroll-y</a> responsive condition applies to any scoped element that has scrolled a lesser or equal (<code>&lt;=</code>) amount to the value specified in a vertical direction.</p>
+   <div class="example" id="example-cdca554e">
+    <a class="self-link" href="#example-cdca554e"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-y" id="ref-for-descdef-element-scroll-y-4">max-scroll-y</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.feed'</span> and <span class="p">(</span>max-scroll-y<span class="nt">: 100px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.feed</code> that has scrolled <code>100px</code> or less vertically will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.7" id="scroll-x"><span class="secno">5.7. </span><span class="content">Scroll-X</span><a class="self-link" href="#scroll-x"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-scroll-x">scroll-x</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-19">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-x" id="ref-for-descdef-element-scroll-x-1">min-scroll-x</a> responsive condition applies to any scoped element that has scrolled a greater or equal (<code>>=</code>) amount to the value specified in a horizontal direction.</p>
+   <div class="example" id="example-37d530df">
+    <a class="self-link" href="#example-37d530df"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-x" id="ref-for-descdef-element-scroll-x-2">min-scroll-x</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.feed'</span> and <span class="p">(</span>min-scroll-x<span class="nt">: 100px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.feed</code> that has scrolled <code>100px</code> or more horizontally will have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-x" id="ref-for-descdef-element-scroll-x-3">max-scroll-x</a> responsive condition applies to any scoped element that has scrolled a lesser or equal (<code>&lt;=</code>) amount to the value specified in a horizontal direction.</p>
+   <div class="example" id="example-1771fa3e">
+    <a class="self-link" href="#example-1771fa3e"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-scroll-x" id="ref-for-descdef-element-scroll-x-4">max-scroll-x</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.feed'</span> and <span class="p">(</span>max-scroll-x<span class="nt">: 100px) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.feed</code> that has scrolled <code>100px</code> or less horizontally will have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.8" id="aspect-ratio"><span class="secno">5.8. </span><span class="content">Aspect-Ratio</span><a class="self-link" href="#aspect-ratio"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-aspect-ratio">aspect-ratio</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-20">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod"><a class="production css" data-link-type="type" href="https://drafts.csswg.org/mediaqueries-4/#typedef-ratio">&lt;ratio></a>
+     <tr>
+      <th>Type:
+      <td>range
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-aspect-ratio" id="ref-for-descdef-element-aspect-ratio-1">min-aspect-ratio</a> responsive condition applies to any scoped element with a greater or equal (<code>>=</code>) aspect ratio, specified as a <code>width</code> and <code>height</code> pair, separated by a slash (<code>/</code>).</p>
+   <div class="example" id="example-6bfccd88">
+    <a class="self-link" href="#example-6bfccd88"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-aspect-ratio" id="ref-for-descdef-element-aspect-ratio-2">min-aspect-ratio</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>min-aspect-ratio<span class="nt">: 16/9) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element that had an aspect ratio of <code>16/9</code> or greater would have a green background.</p>
+   </div>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-aspect-ratio" id="ref-for-descdef-element-aspect-ratio-3">max-aspect-ratio</a> responsive condition applies to any scoped element with a lesser or equal (<code>&lt;=</code>) aspect ratio, specified as a <code>width</code> and <code>height</code> pair, separated by a slash (<code>/</code>).</p>
+   <div class="example" id="example-fa4f4e88">
+    <a class="self-link" href="#example-fa4f4e88"></a> Example <a class="property" data-link-type="propdesc" href="#descdef-element-aspect-ratio" id="ref-for-descdef-element-aspect-ratio-4">max-aspect-ratio</a> element query 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>max-aspect-ratio<span class="nt">: 16/9) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element that had an aspect ratio of <code>16/9</code> or lesser would have a green background.</p>
+   </div>
+   <h3 class="heading settled" data-level="5.9" id="orientation"><span class="secno">5.9. </span><span class="content">Orientation</span><a class="self-link" href="#orientation"></a></h3>
+   <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      <td><dfn class="dfn-paneled css" data-dfn-for="@element" data-dfn-type="descriptor" data-export="" id="descdef-element-orientation">orientation</dfn>
+     <tr>
+      <th>For:
+      <td><a class="css" data-link-type="at-rule" href="#at-ruledef-element" id="ref-for-at-ruledef-element-21">@element</a>
+     <tr>
+      <th>Value:
+      <td class="prod">portrait <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> square <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> landscape
+     <tr>
+      <th>Type:
+      <td>discrete
+   </table>
+   <p>The <a class="property" data-link-type="propdesc" href="#descdef-element-orientation" id="ref-for-descdef-element-orientation-1">orientation</a> responsive condition applies to any scoped element that matches the orientation specified. The following orientations are included: <a class="css" data-link-type="maybe" href="#valdef-element-orientation-landscape" id="ref-for-valdef-element-orientation-landscape-1">landscape</a>, <a class="css" data-link-type="maybe" href="#valdef-element-orientation-square" id="ref-for-valdef-element-orientation-square-1">square</a>, <a class="css" data-link-type="maybe" href="#valdef-element-orientation-portrait" id="ref-for-valdef-element-orientation-portrait-1">portrait</a></p>
+   <h4 class="heading settled" data-level="5.9.1" id="portrait-orientation"><span class="secno">5.9.1. </span><span class="content">Portrait Orientation</span><a class="self-link" href="#portrait-orientation"></a></h4>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="@element/orientation" data-dfn-type="value" data-export="" id="valdef-element-orientation-portrait">portrait</dfn> 
+    <dd>The <a class="property" data-link-type="propdesc" href="#descdef-element-orientation" id="ref-for-descdef-element-orientation-2">orientation</a> is <a class="css" data-link-type="maybe" href="#valdef-element-orientation-portrait" id="ref-for-valdef-element-orientation-portrait-2">portrait</a> if the scoped element has a greater (<code>></code>) height than width 
+   </dl>
+   <div class="example" id="example-fac58591">
+    <a class="self-link" href="#example-fac58591"></a> Element query for <a class="css" data-link-type="maybe" href="#valdef-element-orientation-portrait" id="ref-for-valdef-element-orientation-portrait-3">portrait</a> orientation 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>orientation<span class="nt">: portrait) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that is narrower than it is tall will have a green background.</p>
+   </div>
+   <h4 class="heading settled" data-level="5.9.2" id="square-orientation"><span class="secno">5.9.2. </span><span class="content">Square Orientation</span><a class="self-link" href="#square-orientation"></a></h4>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="@element/orientation" data-dfn-type="value" data-export="" id="valdef-element-orientation-square">square</dfn> 
+    <dd>The <a class="property" data-link-type="propdesc" href="#descdef-element-orientation" id="ref-for-descdef-element-orientation-3">orientation</a> is <a class="css" data-link-type="maybe" href="#valdef-element-orientation-square" id="ref-for-valdef-element-orientation-square-2">square</a> if the scoped element has an equal (<code>=</code>) height and width 
+   </dl>
+   <div class="example" id="example-36810f23">
+    <a class="self-link" href="#example-36810f23"></a> Element query for <a class="css" data-link-type="maybe" href="#valdef-element-orientation-square" id="ref-for-valdef-element-orientation-square-3">square</a> orientation 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>orientation<span class="nt">: square) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that has an equal width and height will have a green background.</p>
+   </div>
+   <h4 class="heading settled" data-level="5.9.3" id="landscape-orientation"><span class="secno">5.9.3. </span><span class="content">Landscape Orientation</span><a class="self-link" href="#landscape-orientation"></a></h4>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="@element/orientation" data-dfn-type="value" data-export="" id="valdef-element-orientation-landscape">landscape</dfn> 
+    <dd>The <a class="property" data-link-type="propdesc" href="#descdef-element-orientation" id="ref-for-descdef-element-orientation-4">orientation</a> is <a class="css" data-link-type="maybe" href="#valdef-element-orientation-landscape" id="ref-for-valdef-element-orientation-landscape-2">landscape</a> if the scoped element has a greater (<code>></code>) width than height 
+   </dl>
+   <div class="example" id="example-e53cedbf">
+    <a class="self-link" href="#example-e53cedbf"></a> Element query for <a class="css" data-link-type="maybe" href="#valdef-element-orientation-landscape" id="ref-for-valdef-element-orientation-landscape-3">landscape</a> orientation 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> and <span class="p">(</span>orientation<span class="nt">: landscape) </span><span class="p">{</span>
+  $this {
+    background: lime;
+  }
+}
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> that is wider than it is tall will have a green background.</p>
+   </div>
+   <h2 class="heading settled" data-level="6" id="css-functions"><span class="secno">6. </span><span class="content">CSS Functions</span><a class="self-link" href="#css-functions"></a></h2>
+   <h3 class="heading settled" data-level="6.1" id="eval"><span class="secno">6.1. </span><span class="content">eval("")</span><a class="self-link" href="#eval"></a></h3>
+   <p class="note" role="note">Note, Much of the functionality of this feature is similar to CSS variables, however being able to execute JavaScript from the vantage point of the element in the scope could perhaps be a way that CSS variables could be used a little differently inside scoped styles or element queries.</p>
+   <p>The <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-1">eval("")</a> function can be used anywhere inside a scoped style or element query. It shares a scope with the element in the root of the scoped style.</p>
+   <div class="railroad">
+    <svg class="railroad-diagram" height="62" viewBox="0 0 345 62" width="345">
+     <g transform="translate(.5 .5)">
+      <path d="M 20 21 v 20 m 10 -20 v 20 m -10 -10 h 20.5" data-type="start" data-updown="10 10"></path>
+      <path d="M40 31h10"></path>
+      <path d="M118 31h10"></path>
+      <g data-type="terminal" data-updown="11 11">
+       <path d="M50 31h0.0"></path>
+       <path d="M118.0 31h0.0"></path>
+       <rect height="22" rx="10" ry="10" width="68" x="50.0" y="20"></rect>
+       <text x="84.0" y="35"> eval("</text>
+      </g>
+      <path d="M128 31h10"></path>
+      <path d="M238 31h10"></path>
+      <g data-type="non-terminal" data-updown="11 11">
+       <path d="M138 31h0.0"></path>
+       <path d="M238.0 31h0.0"></path>
+       <rect height="22" width="100" x="138.0" y="20"></rect>
+       <text x="188.0" y="35"> javascript</text>
+      </g>
+      <path d="M248 31h10"></path>
+      <path d="M294 31h10"></path>
+      <g data-type="terminal" data-updown="11 11">
+       <path d="M258 31h0.0"></path>
+       <path d="M294.0 31h0.0"></path>
+       <rect height="22" rx="10" ry="10" width="36" x="258.0" y="20"></rect>
+       <text x="276.0" y="35"> ")</text>
+      </g>
+      <path d="M 304 31 h 20 m -10 -10 v 20 m 10 -20 v 20" data-type="end" data-updown="10 10"></path>
+     </g>
+    </svg>
+   </div>
+   <p>When using <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-2">eval("")</a> you can write <code>eval</code>, followed by a pair of brackets (<code>(</code>,<code>)</code>) which contain JavaScript code, wrapped in either single (<code>'</code>) or double (<code>"</code>) quotes.</p>
+   <p>This JavaScript can do something simple like reference the value of a variable, perform a simple calculation inline, or it can use the value return by a function.</p>
+   <p class="note" role="note">Note, Unlike CSS variables, the <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-3">eval("")</a> function can be used anywhere in CSS: as a value, a property name, a selector, a '@media' query breakpoint - it can be used for anything, as long as it is inside of a scoped style.</p>
+   <h4 class="heading settled" data-level="6.1.1" id="using-js-variables-in-css"><span class="secno">6.1.1. </span><span class="content">Using JavaScript Variables in CSS</span><a class="self-link" href="#using-js-variables-in-css"></a></h4>
+   <div class="example" id="example-a50be6c9">
+    <a class="self-link" href="#example-a50be6c9"></a> Accessing a JavaScript variable with <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-4">eval("")</a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> brandColor <span class="o">=</span> <span class="s1">'lime'</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'.widget'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      background<span class="o">:</span> <span class="n">eval</span><span class="p">(</span><span class="s2">"brandColor"</span><span class="p">);</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> will have a green background.</p>
+   </div>
+   <h4 class="heading settled" data-level="6.1.2" id="writing-js-in-css"><span class="secno">6.1.2. </span><span class="content">Writing JavaScript in CSS</span><a class="self-link" href="#writing-js-in-css"></a></h4>
+   <div class="example" id="example-8f0b14c9">
+    <a class="self-link" href="#example-8f0b14c9"></a> Evaluating JavaScript Inline with <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-5">eval("")</a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="k">font-size</span><span class="p">:</span> <span class="nf">eval</span><span class="p">(</span><span class="s">"10 * 2"</span><span class="p">)</span>px<span class="p">;</span>
+<span class="p">}</span>
+</pre>
+    <p>In this case our inline JavaScript (<code>10 * 2</code>) evaluates in place, leaving us with a font size of <code>20px</code>.</p>
+   </div>
+   <h4 class="heading settled" data-level="6.1.3" id="using-js-functions-in-css"><span class="secno">6.1.3. </span><span class="content">Using JavaScript Functions in CSS</span><a class="self-link" href="#using-js-functions-in-css"></a></h4>
+   <div class="example" id="example-78004bc6">
+    <a class="self-link" href="#example-78004bc6"></a> Using Values Returned from Functions with <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-6">eval("")</a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">function</span> addTen<span class="p">(</span>number<span class="p">)</span><span class="p">{</span>
+    <span class="kd">var</span> number <span class="o">=</span> parseInt<span class="p">(</span>number<span class="p">)</span> <span class="o">||</span> <span class="mi">0</span>
+    <span class="k">return</span> number <span class="o">+</span> <span class="mi">10</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'.widget'</span> <span class="p">{</span>
+    <span class="nt">font-size</span><span class="o">:</span> <span class="nt">eval</span><span class="o">(</span><span class="s2">"addTen(15)"</span><span class="o">)</span><span class="nt">px</span><span class="o">;</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this case any element with a class of <code>.widget</code> will have a font size of <code>25px</code>.</p>
+   </div>
+   <h4 class="heading settled" data-level="6.1.4" id="replacing-values-in-css"><span class="secno">6.1.4. </span><span class="content">Replacing Values in CSS</span><a class="self-link" href="#replacing-values-in-css"></a></h4>
+   <div class="example" id="example-235e7786">
+    <a class="self-link" href="#example-235e7786"></a> Here is <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-7">eval("")</a> being used as a value: 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> blue <span class="o">=</span> <span class="s1">'#07f'</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'div'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      color<span class="o">:</span> <span class="n">eval</span><span class="p">(</span><span class="s2">"blue"</span><span class="p">);</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>This example would be equivalent to: <code>div { color: #07f; }</code></p>
+   </div>
+   <h4 class="heading settled" data-level="6.1.5" id="replacing-properties-in-css"><span class="secno">6.1.5. </span><span class="content">Replacing Properties in CSS</span><a class="self-link" href="#replacing-properties-in-css"></a></h4>
+   <div class="example" id="example-631ca87a">
+    <a class="self-link" href="#example-631ca87a"></a> Here is <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-8">eval("")</a> being used as a property: 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">input</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> browser <span class="o">=</span> <span class="sr">/Safari/</span><span class="p">.</span>test<span class="p">(</span>navigator<span class="p">.</span>userAgent<span class="p">)</span> <span class="o">?</span> <span class="s1">'-webkit-'</span><span class="o">:</span><span class="s1">''</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'input'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      <span class="n">eval</span><span class="p">(</span><span class="s1">'browser'</span><span class="p">)</span><span class="n">appearance</span><span class="o">:</span> none<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>This example would use the property: <code>-webkit-appearance</code> if the browser was Safari, otherwise would use: <code>appearance</code>.</p>
+   </div>
+   <h4 class="heading settled" data-level="6.1.6" id="replacing-selectors-in-css"><span class="secno">6.1.6. </span><span class="content">Replacing Selectors in CSS</span><a class="self-link" href="#replacing-selectors-in-css"></a></h4>
+   <div class="example" id="example-82befd5f">
+    <a class="self-link" href="#example-82befd5f"></a> Here is <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-9">eval("")</a> replacing a list of selectors: 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> buttonish <span class="o">=</span> <span class="s1">'[type=button], [type=submit], [type=reset], button'</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'html'</span> <span class="p">{</span>
+    <span class="nt">eval</span><span class="o">(</span><span class="s1">'buttonish'</span><span class="o">)</span> <span class="p">{</span>
+      <span class="n">appearance</span><span class="o">:</span> none<span class="p">;</span>
+      color<span class="o">:</span> black<span class="p">;</span>
+      background<span class="o">:</span> white<span class="p">;</span>
+      border<span class="o">:</span> <span class="m">1px</span> solid <span class="n">currentColor</span><span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>This example would be equivalent the following rule:</p>
+<pre class="language-css highlight"><span class="nt">[type=button], [type=submit], [type=reset], button </span><span class="p">{</span>
+  <span class="k">appearance</span><span class="p">:</span> none<span class="p">;</span>
+  <span class="k">color</span><span class="p">:</span> black<span class="p">;</span>
+  <span class="k">background</span><span class="p">:</span> white<span class="p">;</span>
+  <span class="k">border</span><span class="p">:</span> <span class="m">1</span><span class="l">px</span> solid currentColor<span class="p">;</span>
+<span class="p">}</span>
+</pre>
+    <p>Check the <a href="#using-variables-as-selectors">Using Variables as Selectors</a> example below for a more elaborate demonstration, including pseudo-classes like <code>:hover</code> or <code>:focus</code></p>
+   </div>
+   <p class="note" role="note">Note, Because <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-10">eval("")</a> works everywhere in CSS inside of a scoped style, it’s also possible to use inside the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-content-3/#propdef-content">content</a> property for pseudo-elements like <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-content-3/#valdef-content-before">before</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-content-3/#valdef-content-after">after</a>.</p>
+   <h4 class="heading settled" data-level="6.1.7" id="it-selector"><span class="secno">6.1.7. </span><span class="content"><code>$it</code> selector</span><a class="self-link" href="#it-selector"></a></h4>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="meta-selectors" data-dfn-type="selector" data-export="" id="selectordef-meta-selectors-it">$it</dfn> 
+    <dd>
+      By default the inline evaluation of <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-11">eval("")</a> shares the same scope in JavaScript as the scoped element. This means for a scoped style like <code>@element '.widget' {}</code>, things like <code>innerHTML</code> represent the <code>innerHTML</code> of the elements with <code>.widget</code>. This would also apply individually to each element if more than one element on the page matches that selector. In this example we can use <code>parentNode</code> inside of <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-12">eval("")</a> to check how many child elements the parent element holding any <code>.widget</code> element contains. 
+     <div class="example" id="example-a827d451">
+      <a class="self-link" href="#example-a827d451"></a> Example of <span class="css">eval("")</span> with Implicit Context 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this:before </span><span class="p">{</span>
+    <span class="k">content</span><span class="p">:</span> <span class="s">'eval("parentNode.children.length")'</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case the pseudo-element <code>:before</code> the content of any element with a class of <code>.widget</code> will contain text of the number of child elements inside the parent element of our <code>.widget</code> element.</p>
+     </div>
+     <p>The meta-selector <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-it" id="ref-for-selectordef-meta-selectors-it-1">$it</a> works inside <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-13">eval("")</a> as a placeholder for the scoped element. The following example is functionally equivalent to the last example:</p>
+     <div class="example" id="example-4881b5ba">
+      <a class="self-link" href="#example-4881b5ba"></a> Example of <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-14">eval("")</a> with the <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-it" id="ref-for-selectordef-meta-selectors-it-2">$it</a> Selector 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this:before </span><span class="p">{</span>
+    <span class="k">content</span><span class="p">:</span> <span class="s">'eval("$it.parentNode.children.length")'</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+     </div>
+   </dl>
+   <h2 class="heading settled" data-level="7" id="element-percentage-units"><span class="secno">7. </span><span class="content">Element-percentage Units</span><a class="self-link" href="#element-percentage-units"></a></h2>
+   <p>Just as CSS has viewport-percentage units: <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vmin">vmin</a>, and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vmax">vmax</a> which represent a distance equal to 1% of the viewport width, height, shortest edge, and longest edge, in a similar way the following element-percentage units <a class="css" data-link-type="maybe" href="#ew" id="ref-for-ew-1">ew</a>, <a class="css" data-link-type="maybe" href="#eh" id="ref-for-eh-1">eh</a>, <a class="css" data-link-type="maybe" href="#emin" id="ref-for-emin-1">emin</a>, and <a class="css" data-link-type="maybe" href="#emax" id="ref-for-emax-1">emax</a> represent a distance equal to 1% of the element’s own width, height, shortest edge, and longest edge. When the width of height of the element changes, the value of these units scale accordingly.</p>
+   <p class="note" role="note">Note, These new <a data-link-type="dfn" href="#eq-unit" id="ref-for-eq-unit-1">eq-unit</a> units always refer to the dimensions of the element in the scope, and can be used inside of a scoped style or element query to style other elements.</p>
+   <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="eq-unit" data-dfn-type="value" data-export="" data-lt="ew" id="ew">ew unit</dfn> 
+    <dd>
+      Equal to 1% of the width of the scoped element 
+     <div class="example" id="example-8ec51de7">
+      <a class="self-link" href="#example-8ec51de7"></a> Example of ew Units Inside a Scoped Style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this </span><span class="p">{</span>
+    <span class="k">font-size</span><span class="p">:</span> <span class="m">10</span><span class="l">ew</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element’s width.</p>
+     </div>
+     <p class="note" role="note">Note, This unit is similar to the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> viewport unit, but based on the scoped element’s dimensions.</p>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="eq-unit" data-dfn-type="value" data-export="" data-lt="eh" id="eh">eh unit</dfn> 
+    <dd>
+      Equal to 1% of the height of the scoped element 
+     <div class="example" id="example-55e98baa">
+      <a class="self-link" href="#example-55e98baa"></a> Example of eh Units Inside a Scoped Style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this </span><span class="p">{</span>
+    <span class="k">font-size</span><span class="p">:</span> <span class="m">10</span><span class="l">eh</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element’s height.</p>
+     </div>
+     <p class="note" role="note">Note, This unit is similar to the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> viewport unit, but based on the scoped element’s dimensions.</p>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="eq-unit" data-dfn-type="value" data-export="" data-lt="emin" id="emin">emin unit</dfn> 
+    <dd>
+      Equal to the smaller of ew or eh 
+     <div class="example" id="example-84d58a8e">
+      <a class="self-link" href="#example-84d58a8e"></a> Example of emin Units Inside a Scoped Style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this </span><span class="p">{</span>
+    <span class="k">font-size</span><span class="p">:</span> <span class="m">10</span><span class="l">emin</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element’s shortest edge.</p>
+     </div>
+     <p class="note" role="note">Note, This unit is similar to the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vmin">vmin</a> viewport unit, but based on the scoped element’s dimensions.</p>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="eq-unit" data-dfn-type="value" data-export="" data-lt="emax" id="emax">emax unit</dfn> 
+    <dd>
+      Equal to the larger of ew or eh 
+     <div class="example" id="example-ea2b3e97">
+      <a class="self-link" href="#example-ea2b3e97"></a> Example of emax Units Inside a Scoped Style 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'.widget'</span> <span class="p">{</span>
+  <span class="nt">$this </span><span class="p">{</span>
+    <span class="k">font-size</span><span class="p">:</span> <span class="m">10</span><span class="l">emax</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+      <p>In this case the font size of any element with a class of <code>.widget</code> is equal to 10% of the scoped element’s longest edge.</p>
+     </div>
+     <p class="note" role="note">Note, This unit is similar to the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vmax">vmax</a> viewport unit, but based on the scoped element’s dimensions.</p>
+   </dl>
+   <h2 class="heading settled" data-level="8" id="examples-of-element-queries"><span class="secno">8. </span><span class="content">Examples of Scoped Styles &amp; Element Queries</span><a class="self-link" href="#examples-of-element-queries"></a></h2>
+   <h3 class="heading settled" data-level="8.1" id="example-scoped-styles"><span class="secno">8.1. </span><span class="content">Examples of valid scoped styles</span><a class="self-link" href="#example-scoped-styles"></a></h3>
+   <div class="example" id="example-950901a4">
+    <a class="self-link" href="#example-950901a4"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div'</span> <span class="p">{}</span>
+</pre>
+   </div>
+   <div class="example" id="example-4e71e53b">
+    <a class="self-link" href="#example-4e71e53b"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div, span'</span> <span class="p">{}</span>
+</pre>
+   </div>
+   <div class="example" id="example-b0263c7e">
+    <a class="self-link" href="#example-b0263c7e"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div'</span> and <span class="p">(</span>min-width<span class="nt">: 500px) </span><span class="p">{</span><span class="p">}</span>
+</pre>
+   </div>
+   <div class="example" id="example-a3e255ae">
+    <a class="self-link" href="#example-a3e255ae"></a> 
+<pre class="language-css highlight"><span class="n">@element</span> <span class="s">'div'</span> and <span class="p">(</span>min-width<span class="nt">: 500px) and (min-lines: 3) </span><span class="p">{</span><span class="p">}</span>
+</pre>
+   </div>
+   <h3 class="heading settled" data-level="8.2" id="wrapper-free-responsive-iframe"><span class="secno">8.2. </span><span class="content">Wrapper-free responsive iframe resize</span><a class="self-link" href="#wrapper-free-responsive-iframe"></a></h3>
+   <div class="example" id="example-e3f9465f">
+    <a class="self-link" href="#example-e3f9465f"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">width</span><span class="o">=</span><span class="s">"640"</span> <span class="na">height</span><span class="o">=</span><span class="s">"360"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'iframe'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+      height<span class="o">:</span> <span class="n">eval</span><span class="p">(</span><span class="s1">'offsetWidth / (width / height)'</span><span class="p">)</span>px<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this example the <code>iframe</code> element has a <code>width=""</code> and <code>height=""</code> attribute supplied in HTML which is being accessed from CSS using <code>$it.width</code> and <code>$it.height</code> inside our <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-15">eval("")</a> function. Because we are able to compute the HTML attributes directly, this one rule will make multiple <code>iframe</code> elements with <em>different</em> attribute values on the same page responsive, as it computes each iframe separately as <code>$this</code>.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.3" id="faking-input-empty"><span class="secno">8.3. </span><span class="content">Faking <code>input:empty</code></span><a class="self-link" href="#faking-input-empty"></a></h3>
+   <div class="example" id="example-baf82963">
+    <a class="self-link" href="#example-baf82963"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">input</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="c">/* input:empty */</span>
+  <span class="k">@element</span> <span class="s1">'input'</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">max-characters</span><span class="o">:</span> <span class="nt">0</span><span class="o">)</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      background<span class="o">:</span> red<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+  <span class="c">/* input:not(:empty) */</span>
+  <span class="k">@element</span> <span class="s1">'input'</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">min-characters</span><span class="o">:</span> <span class="nt">1</span><span class="o">)</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      background<span class="o">:</span> lime<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this example we are able to apply styles based on whether there are zero or at least one characters inside any <code>input</code> element. CSS has the pseudo-class <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#empty-pseudo">:empty</a>, however it doesn’t apply to all elements (like <code>input</code> elements) so by using <code>max-characters</code> and <code>min-characters</code> with element queries we are able to express and style a similar idea.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.4" id="auto-expanding-textarea"><span class="secno">8.4. </span><span class="content">Auto-expanding <code>textarea</code></span><a class="self-link" href="#auto-expanding-textarea"></a></h3>
+   <div class="example" id="example-fda853eb">
+    <a class="self-link" href="#example-fda853eb"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">textarea</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">textarea</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'textarea'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      height<span class="o">:</span> <span class="n">eval</span><span class="p">(</span><span class="s2">"style.height='inherit';style.height=scrollHeight+'px'"</span><span class="p">);</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this example we are using <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-16">eval("")</a> to reset the height value of our element and immediately set it to the scrollHeight of the element, ensuring that no matter how many lines of text it contains, it will always expand &amp; contract to contain all of them.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.5" id="display-browser-dimensions"><span class="secno">8.5. </span><span class="content">Display Browser Dimensions</span><a class="self-link" href="#display-browser-dimensions"></a></h3>
+   <div class="example" id="example-66971180">
+    <a class="self-link" href="#example-66971180"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">':root'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span><span class="nd">:before</span> <span class="p">{</span>
+      content<span class="o">:</span> <span class="s1">'eval("window.innerWidth") × eval("window.innerHeight")'</span><span class="p">;</span>
+      position<span class="o">:</span> fixed<span class="p">;</span>
+      top<span class="o">:</span> <span class="m">.5em</span><span class="p">;</span>
+      left<span class="o">:</span> <span class="m">.5em</span><span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>This example will create a new pseudo-element on our ':root' element (the HTML element) and uses <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-17">eval("")</a> to display the <code>innerWidth</code> and <code>innerHeight</code> values of our <code>window</code>.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.6" id="self-responsive-grid"><span class="secno">8.6. </span><span class="content">Self-responsive Grid</span><a class="self-link" href="#self-responsive-grid"></a></h3>
+   <div class="example" id="example-2beb31a9">
+    <a class="self-link" href="#example-2beb31a9"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">h2</span><span class="p">></span>Responsive Grid<span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Small = full width, Medium = thirds, Large = sixths.<span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">section</span> <span class="na">data-grid</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 medium-split-3 large-split-6"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">section</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">h2</span><span class="p">></span>Split Grid<span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Small = half width, Medium = 1, 2, 3, 4 split, Large = 4, 3, 2, 1 split.<span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">section</span> <span class="na">data-grid</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-1 large-split-4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-2 large-split-4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-2 large-split-4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-3 large-split-4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-3 large-split-3"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-3 large-split-3"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-4 large-split-3"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-4 large-split-2"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-4 large-split-2"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-5 medium-split-4 large-split-1"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">section</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">h2</span><span class="p">></span>Hidden Elements<span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Small = Hide Small, Medium = Hide Medium, Large = Hide Large.<span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">section</span> <span class="na">data-grid</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 hide-small"</span><span class="p">></span>Small<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 hide-medium"</span><span class="p">></span>Medium<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"col-10 hide-large"</span><span class="p">></span>Large<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">section</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="o">*</span> <span class="p">{</span>
+    <span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> border<span class="o">-</span><span class="n">box</span><span class="p">;</span>
+  <span class="p">}</span>
+  <span class="o">[</span><span class="nt">data-grid</span><span class="o">]</span> <span class="nt">div</span> <span class="p">{</span>
+    min-height<span class="o">:</span> <span class="m">50px</span><span class="p">;</span>
+    background<span class="o">:</span> lime<span class="p">;</span>
+    border<span class="o">:</span> <span class="m">5px</span> solid white<span class="p">;</span>
+  <span class="p">}</span>
+  <span class="c">/* Element Query Grid */</span>
+  <span class="k">@element</span> <span class="s1">'[data-grid]'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span><span class="o">,</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">*</span> <span class="p">{</span>
+      <span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> border<span class="o">-</span><span class="n">box</span><span class="p">;</span>
+    <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span><span class="nd">:after</span><span class="o">,</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">data-row</span><span class="o">]</span><span class="nd">:after</span> <span class="p">{</span>
+      content<span class="o">:</span> <span class="s1">''</span><span class="p">;</span>
+      display<span class="o">:</span> block<span class="p">;</span>
+      clear<span class="o">:</span> both<span class="p">;</span>
+    <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">-col-</span><span class="o">]</span><span class="o">,</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">-split-</span><span class="o">]</span> <span class="p">{</span> float<span class="o">:</span> left<span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">10%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">20%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">30%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">40%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">50%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">60%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">70%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">80%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">90%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">col-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">1</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">2</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">3</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">4</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">5</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">6</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">7</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">8</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">9</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">^</span><span class="o">=</span><span class="nt">split-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">10</span><span class="p">);</span> <span class="p">}</span>
+  <span class="p">}</span>
+  <span class="k">@element</span> <span class="s1">'[data-grid]'</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">max-width</span><span class="o">:</span> <span class="nt">400px</span><span class="o">)</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">10%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">20%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">30%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">40%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">50%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">60%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">70%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">80%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">90%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-col-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">1</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">2</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">3</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">4</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">5</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">6</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">7</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">8</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">9</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">small-split-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">10</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">hide-small</span><span class="o">]</span> <span class="p">{</span> display<span class="o">:</span> none<span class="p">;</span> <span class="p">}</span>
+  <span class="p">}</span>
+  <span class="k">@element</span> <span class="s1">'[data-grid]'</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">min-width</span><span class="o">:</span> <span class="nt">400px</span><span class="o">)</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">max-width</span><span class="o">:</span> <span class="nt">800px</span><span class="o">)</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">10%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">20%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">30%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">40%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">50%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">60%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">70%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">80%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">90%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-col-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">1</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">2</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">3</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">4</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">5</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">6</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">7</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">8</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">9</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">medium-split-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">10</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">hide-medium</span><span class="o">]</span> <span class="p">{</span> display<span class="o">:</span> none<span class="p">;</span> <span class="p">}</span>
+  <span class="p">}</span>
+  <span class="k">@element</span> <span class="s1">'[data-grid]'</span> <span class="nt">and</span> <span class="o">(</span><span class="nt">min-width</span><span class="o">:</span> <span class="nt">800px</span><span class="o">)</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">10%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">20%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">30%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">40%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">50%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">60%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">70%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">80%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">90%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-col-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-1</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">1</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-2</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">2</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-3</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">3</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-4</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">4</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-5</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">5</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-6</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">6</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-7</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">7</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-8</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">8</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-9</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">9</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">large-split-10</span><span class="o">]</span> <span class="p">{</span> width<span class="o">:</span> <span class="n">calc</span><span class="p">(</span><span class="m">100%</span><span class="o">/</span><span class="m">10</span><span class="p">);</span> <span class="p">}</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="o">[</span><span class="nt">class</span><span class="o">*</span><span class="o">=</span><span class="nt">hide-large</span><span class="o">]</span> <span class="p">{</span> display<span class="o">:</span> none<span class="p">;</span> <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>This example uses <a class="css" data-link-type="maybe" href="#at-ruledef-element" id="ref-for-at-ruledef-element-22">@element</a> queries to apply the different responsive styles to our grid when the grid element itself reaches certain breakpoints. Because the styles are scoped to each grid using <a class="css" data-link-type="selector" href="#selectordef-meta-selectors-this" id="ref-for-selectordef-meta-selectors-this-6">$this</a>, we can use these same styles to power many grids in the same layout all using the same styles.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.7" id="using-variables-as-selectors"><span class="secno">8.7. </span><span class="content">Using Variables as Selectors</span><a class="self-link" href="#using-variables-as-selectors"></a></h3>
+   <div class="example" id="example-7dacbc69">
+    <a class="self-link" href="#example-7dacbc69"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">hidden</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">hidden</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">text</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">text</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">search</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">search</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">tel</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">tel</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">url</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">url</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">email</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">email</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">password</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">password</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">date</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">date</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">month</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">month</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">week</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">week</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">time</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">time</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">datetime-local</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">datetime-local</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">number</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">number</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">input</span> <span class="na">type</span><span class="o">=</span><span class="s">color</span> <span class="na">placeholder</span><span class="o">=</span><span class="s">color</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">textarea</span><span class="p">></span>textarea<span class="p">&lt;</span><span class="p">/</span><span class="nt">textarea</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> textish <span class="o">=</span> <span class="p">[</span>
+    <span class="s1">'[type=text]'</span><span class="p">,</span> <span class="s1">'[type=search]'</span><span class="p">,</span> <span class="s1">'[type=tel]'</span><span class="p">,</span> <span class="s1">'[type=url]'</span><span class="p">,</span> <span class="s1">'[type=email]'</span><span class="p">,</span> <span class="s1">'[type=password]'</span><span class="p">,</span> <span class="s1">'[type=date]'</span><span class="p">,</span> <span class="s1">'[type=month]'</span><span class="p">,</span> <span class="s1">'[type=week]'</span><span class="p">,</span> <span class="s1">'[type=time]'</span><span class="p">,</span> <span class="s1">'[type=datetime-local]'</span><span class="p">,</span> <span class="s1">'[type=number]'</span><span class="p">,</span> <span class="s1">'[type=color]'</span><span class="p">,</span> <span class="s1">'textarea'</span>
+  <span class="p">]</span>
+  <span class="cm">/* return selectors with :states using action(array,state) */</span>
+  <span class="kd">function</span> action<span class="p">(</span>array<span class="p">,</span>state<span class="p">)</span><span class="p">{</span>
+    <span class="kd">var</span> selectors <span class="o">=</span> <span class="s1">''</span><span class="p">;</span>
+    <span class="k">for</span><span class="p">(</span>i<span class="o">=</span><span class="mi">0</span><span class="p">;</span> i<span class="o">&lt;</span>array<span class="p">.</span>length<span class="p">;</span> i<span class="o">++</span><span class="p">)</span><span class="p">{</span>
+      selectors <span class="o">+=</span> array<span class="p">[</span>i<span class="p">]</span><span class="o">+</span><span class="s1">':'</span><span class="o">+</span>state
+      <span class="k">if</span> <span class="p">(</span>i <span class="o">&lt;</span> array<span class="p">.</span>length<span class="o">-</span><span class="mi">1</span><span class="p">)</span><span class="p">{</span>
+        selectors <span class="o">+=</span> <span class="s1">', '</span>
+      <span class="p">}</span>
+    <span class="p">}</span>
+    <span class="k">return</span> selectors
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="c">/* set width for most inputs */</span>
+  <span class="k">@element</span> <span class="s1">':root'</span> <span class="p">{</span>
+    <span class="c">/* Style all selectors in 'textish' array */</span>
+    <span class="nt">eval</span><span class="o">(</span><span class="s1">'textish'</span><span class="o">)</span> <span class="p">{</span>
+      display<span class="o">:</span> block<span class="p">;</span>
+      width<span class="o">:</span> <span class="m">100%</span><span class="p">;</span>
+    <span class="p">}</span>
+    <span class="c">/* Add ':hover' to all selectors in 'textish' array */</span>
+    <span class="nt">eval</span><span class="o">(</span><span class="s1">'action(textish,"hover")'</span><span class="o">)</span> <span class="p">{</span>
+      background<span class="o">:</span> lime<span class="p">;</span>
+    <span class="p">}</span>
+    <span class="c">/* Add ':focus' to all selectors in 'textish' array */</span>
+    <span class="nt">eval</span><span class="o">(</span><span class="s1">'action(textish,"focus")'</span><span class="o">)</span> <span class="p">{</span>
+      background<span class="o">:</span> red<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this example we use <a data-link-type="functionish" href="#funcdef-eval" id="ref-for-funcdef-eval-18">eval("")</a> to return either a list of selectors (stored as strings in a JavaScript array) or we use the return from a function that allows us to append strings like ':hover', or ':focus' to each selector as it gives them to use as a selector or selector list in our CSS inside of a scoped style. For manipulating or styling many similar things (like text-style inputs but not other inputs) we can simplify the selectors we need to use throughout our CSS while maintaining full control over what gets styled.</p>
+   </div>
+   <h3 class="heading settled" data-level="8.8" id="clamped-numbers-in-CSS"><span class="secno">8.8. </span><span class="content">Clamped Numbers in CSS</span><a class="self-link" href="#clamped-numbers-in-CSS"></a></h3>
+   <div class="example" id="example-44b5a47f">
+    <a class="self-link" href="#example-44b5a47f"></a> 
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">h1</span><span class="p">></span>Headline<span class="p">&lt;</span><span class="p">/</span><span class="nt">h1</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">function</span> clamp<span class="p">(</span>min<span class="p">,</span>mid<span class="p">,</span>max<span class="p">)</span><span class="p">{</span>
+    <span class="k">return</span> Math<span class="p">.</span>min<span class="p">(</span>Math<span class="p">.</span>max<span class="p">(</span>min<span class="p">,</span>mid<span class="p">)</span><span class="p">,</span>max<span class="p">)</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="k">@element</span> <span class="s1">'h1'</span> <span class="p">{</span>
+    <span class="o">$</span><span class="nt">this</span> <span class="p">{</span>
+      font-size<span class="o">:</span> <span class="n">eval</span><span class="p">(</span><span class="s1">'clamp(50,innerWidth/10,100)'</span><span class="p">)</span>px<span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+</pre>
+    <p>In this example our font size prefers to be equal to <code>window.innerWidth/10</code> pixels wide, but our JavaScript function will clamp that value for us, ensuring that if <code>innerWidth/10</code> is less than 50, our font size will go no lower than <code>50px</code>, and if <code>innerWidth/10</code> is greater than 100, our font size will grow no larger than <code>100px</code>.</p>
+   </div>
+  </main>
+  <div data-fill-with="conformance">
+   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+            The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+            in the normative parts of this document
+            are to be interpreted as described in RFC 2119.
+            However, for readability,
+            these words do not appear in all uppercase letters in this specification. </p>
+   <p> All of the text of this specification is normative
+            except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+   <p> Examples in this specification are introduced with the words “for example”
+            or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+   <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
+   <p> Informative notes begin with the word “Note”
+            and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+   <p class="note" role="note"> Note, this is an informative note. </p>
+  </div>
+<script>
+(function() {
+  "use strict";
+  var collapseSidebarText = '<span aria-hidden="true">←</span> '
+                          + '<span>Collapse Sidebar</span>';
+  var expandSidebarText   = '<span aria-hidden="true">→</span> '
+                          + '<span>Pop Out Sidebar</span>';
+  var tocJumpText         = '<span aria-hidden="true">↑</span> '
+                          + '<span>Jump to Table of Contents</span>';
+
+  var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+  var autoToggle   = function(e){ toggleSidebar(e.matches) };
+  if(sidebarMedia.addListener) {
+    sidebarMedia.addListener(autoToggle);
+  }
+
+  function toggleSidebar(on) {
+    if (on == undefined) {
+      on = !document.body.classList.contains('toc-sidebar');
+    }
+
+    /* Don’t scroll to compensate for the ToC if we’re above it already. */
+    var headY = 0;
+    var head = document.querySelector('.head');
+    if (head) {
+      // terrible approx of "top of ToC"
+      headY += head.offsetTop + head.offsetHeight;
+    }
+    var skipScroll = window.scrollY < headY;
+
+    var toggle = document.getElementById('toc-toggle');
+    var tocNav = document.getElementById('toc');
+    if (on) {
+      var tocHeight = tocNav.offsetHeight;
+      document.body.classList.add('toc-sidebar');
+      document.body.classList.remove('toc-inline');
+      toggle.innerHTML = collapseSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, 0 - tocHeight);
+      }
+      tocNav.focus();
+      sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
+    }
+    else {
+      document.body.classList.add('toc-inline');
+      document.body.classList.remove('toc-sidebar');
+      toggle.innerHTML = expandSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, tocNav.offsetHeight);
+      }
+      if (toggle.matches(':hover')) {
+        /* Unfocus button when not using keyboard navigation,
+           because I don’t know where else to send the focus. */
+        toggle.blur();
+      }
+    }
+  }
+
+  function createSidebarToggle() {
+    /* Create the sidebar toggle in JS; it shouldn’t exist when JS is off. */
+    var toggle = document.createElement('a');
+      /* This should probably be a button, but appearance isn’t standards-track.*/
+    toggle.id = 'toc-toggle';
+    toggle.class = 'toc-toggle';
+    toggle.href = '#toc';
+    toggle.innerHTML = collapseSidebarText;
+
+    sidebarMedia.addListener(autoToggle);
+    var toggler = function(e) {
+      e.preventDefault();
+      sidebarMedia.removeListener(autoToggle); // persist explicit off states
+      toggleSidebar();
+      return false;
+    }
+    toggle.addEventListener('click', toggler, false);
 
 
+    /* Get <nav id=toc-nav>, or make it if we don’t have one. */
+    var tocNav = document.getElementById('toc-nav');
+    if (!tocNav) {
+      tocNav = document.createElement('p');
+      tocNav.id = 'toc-nav';
+      /* Prepend for better keyboard navigation */
+      document.body.insertBefore(tocNav, document.body.firstChild);
+    }
+    /* While we’re at it, make sure we have a Jump to Toc link. */
+    var tocJump = document.getElementById('toc-jump');
+    if (!tocJump) {
+      tocJump = document.createElement('a');
+      tocJump.id = 'toc-jump';
+      tocJump.href = '#toc';
+      tocJump.innerHTML = tocJumpText;
+      tocNav.appendChild(tocJump);
+    }
 
-   <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
+    tocNav.appendChild(toggle);
+  }
 
+  var toc = document.getElementById('toc');
+  if (toc) {
+    createSidebarToggle();
+    toggleSidebar(sidebarMedia.matches);
 
-   <p>Given a complex responsive layout, developers often require granular control over styling elements relative to the size of their parent container rather than the viewport size. Container queries allow an author to control styling based on the size of a containing element rather than the size of the user’s viewport.</p>
+    /* If the sidebar has been manually opened and is currently overlaying the text
+       (window too small for the MQ to add the margin to body),
+       then auto-close the sidebar once you click on something in there. */
+    toc.addEventListener('click', function(e) {
+      if(e.target.tagName.toLowerCase() == "a" && document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
+        toggleSidebar(false);
+      }
+    }, false);
+  }
+  else {
+    console.warn("Can’t find Table of Contents. Please use <nav id='toc'> around the ToC.");
+  }
 
+  /* Wrap tables in case they overflow */
+  var tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
+  var numTables = tables.length;
+  for (var i = 0; i < numTables; i++) {
+    var table = tables[i];
+    var wrapper = document.createElement('div');
+    wrapper.className = 'overlarge';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  }
 
-
-   <h3 class="heading settled" data-level="1.1" id="abstract0"><span class="secno">1.1. </span><span class="content">Abstract</span><a class="self-link" href="#abstract0"></a></h3>
-
-
-   <h4 class="heading settled" data-level="1.1.1" id="mq-problems"><span class="secno">1.1.1. </span><span class="content">Limitations of Viewport-Based Media Queries ## {#mq-problems}</span><a class="self-link" href="#mq-problems"></a></h4>
-(This section is not normative.)
-
-
-   <p>Limiting breakpoints to viewport size fundamentally conflicts with the goal of creating modular page components, often requiring a number of redundant CSS rules and complex exception cases spanning multiple viewport-based breakpoints. This problem is compounded depending on how dramatically a module adapts at each of its breakpoints. Once viewport-based breakpoints have been tuned to suit the limited and predictable number of contexts a module might occupy, adjustments to styling elsewhere on the page (layout, width, padding/margins, etc.) may cause a need to revisit a module’s viewport-based breakpoints completely, as those styles are disconnected from the context of the module itself.</p>
-
-
-   <h3 class="heading settled" data-level="1.2" id="when-to-use"><span class="secno">1.2. </span><span class="content">When to use Container Queries</span><a class="self-link" href="#when-to-use"></a></h3>
-
-
-   <p>Container queries are intended for use when…</p>
-
-
-
-   <h3 class="heading settled" data-level="1.3" id="usage"><span class="secno">1.3. </span><span class="content">Examples of Usage</span><a class="self-link" href="#usage"></a></h3>
-
-
-   <p>[[Inside a CSS stylesheet, one can declare that sections apply to certain media types:]]</p>
-
-
-   <div class="example" id="example-1"><a class="self-link" href="#example-1"></a>
-	```css
-		.element:media( min-width: 30em ) screen {
-
-
-    <p>}</p>
-	```
-</div>
-
-
-
-   <h2 class="heading settled" data-level="2" id="container-queries"><span class="secno">2. </span><span class="content">Container Queries</span><a class="self-link" href="#container-queries"></a></h2>
-
-
-   <h3 class="heading settled" data-level="2.1" id="syntax"><span class="secno">2.1. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-
-
-   <p>The formal container query syntax is described in this section, with the rule/property grammar syntax defined in <a data-link-type="biblio" href="#biblio-css3syn">[CSS3SYN]</a> and <a data-link-type="biblio" href="#biblio-css3val">[CSS3VAL]</a>.</p>
-
-
-
-   <h2 class="heading settled" data-level="3" id="defs"><span class="secno">3. </span><span class="content">Definitions</span><a class="self-link" href="#defs"></a></h2>
-
-
-   <p>The following terms are used throughout this specification so they are gathered here for the readers convenience. The following list of terms is not exhaustive; other terms are defined throughout this specification.</p>
-
-
-
-   <h2 class="heading settled" data-level="4" id="acks"><span class="secno">4. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acks"></a></h2>
-
-
-   <p>A <a href="http://www.w3.org/community/respimg/participants">complete list of participants</a> of the Responsive Issues Community Group is available at the W3C Community Group Website.</p>
-
-</main>
-
-  <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">
-Conformance</span><a class="self-link" href="#conformance"></a></h2>
-
-    
-  <p>
-        Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
-        The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
-        in the normative parts of this document
-        are to be interpreted as described in RFC 2119.
-        However, for readability,
-        these words do not appear in all uppercase letters in this specification.
-
-    </p>
-  <p>
-        All of the text of this specification is normative
-        except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a>
-
-    </p>
-  <p>
-        Examples in this specification are introduced with the words “for example”
-        or are set apart from the normative text with <code>class="example"</code>, like this:
-
-    </p>
-  <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a>
-        This is an example of an informative example.
-    </div>
-
-    
-  <p>
-        Informative notes begin with the word “Note”
-        and are set apart from the normative text with <code>class="note"</code>, like this:
-
-    </p>
-  <p class="note" role="note">
-        Note, this is an informative note.
-
-
-
-</p>
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+})();
+</script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#descdef-element-aspect-ratio">aspect-ratio</a><span>, in §5.8</span>
+   <li><a href="#descdef-element-characters">characters</a><span>, in §5.3</span>
+   <li><a href="#descdef-element-children">children</a><span>, in §5.5</span>
+   <li><a href="#eh">eh</a><span>, in §7</span>
+   <li><a href="#at-ruledef-element">@element</a><span>, in §3</span>
+   <li><a href="#emax">emax</a><span>, in §7</span>
+   <li><a href="#emin">emin</a><span>, in §7</span>
+   <li><a href="#typedef-eq-condition">&lt;eq-condition></a><span>, in §3</span>
+   <li><a href="#typedef-eq-name">&lt;eq-name></a><span>, in §3</span>
+   <li><a href="#typedef-eq-prelude">&lt;eq-prelude></a><span>, in §3</span>
+   <li><a href="#eq-unit">eq-unit</a><span>, in §3</span>
+   <li><a href="#typedef-eq-value">&lt;eq-value></a><span>, in §3</span>
+   <li><a href="#funcdef-eval">eval()</a><span>, in §3</span>
+   <li><a href="#ew">ew</a><span>, in §7</span>
+   <li><a href="#descdef-element-height">height</a><span>, in §5.2</span>
+   <li><a href="#selectordef-meta-selectors-it">$it</a><span>, in §6.1.7</span>
+   <li><a href="#valdef-element-orientation-landscape">landscape</a><span>, in §5.9.3</span>
+   <li><a href="#descdef-element-lines">lines</a><span>, in §5.4</span>
+   <li><a href="#selectordef-meta-selectors">meta-selectors</a><span>, in §3</span>
+   <li><a href="#selectordef-meta-selectors-next">$next</a><span>, in §4.1</span>
+   <li><a href="#descdef-element-orientation">orientation</a><span>, in §5.9</span>
+   <li><a href="#selectordef-meta-selectors-parent">$parent</a><span>, in §4.1</span>
+   <li><a href="#valdef-element-orientation-portrait">portrait</a><span>, in §5.9.1</span>
+   <li><a href="#selectordef-meta-selectors-prev">$prev</a><span>, in §4.1</span>
+   <li><a href="#descdef-element-scroll-x">scroll-x</a><span>, in §5.7</span>
+   <li><a href="#descdef-element-scroll-y">scroll-y</a><span>, in §5.6</span>
+   <li><a href="#valdef-element-orientation-square">square</a><span>, in §5.9.2</span>
+   <li><a href="#selectordef-meta-selectors-this">$this</a><span>, in §4.1</span>
+   <li><a href="#descdef-element-width">width</a><span>, in §5.1</span>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[css-conditional-3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">@media</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[css-content-3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-content-3/#valdef-content-after">after</a>
+     <li><a href="https://drafts.csswg.org/css-content-3/#valdef-content-before">before</a>
+     <li><a href="https://drafts.csswg.org/css-content-3/#propdef-content">content</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS3SYN]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">&lt;stylesheet></a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS3VAL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-values-3/#integer-value">&lt;integer></a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS3VAL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">&lt;dimension></a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#vh">vh</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#vmax">vmax</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#vmin">vmin</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#vw">vw</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[MEDIAQUERIES-4]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/mediaqueries-4/#typedef-ratio">&lt;ratio></a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[selectors-4]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/selectors-4/#empty-pseudo">:empty</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#root-pseudo">:root</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">&lt;selector-list></a>
+     <li><a href="https://www.w3.org/TR/selectors4/#ltselector">&lt;selector></a>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-css3syn"><a class="self-link" href="#biblio-css3syn"></a>[CSS3SYN]
-   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/">CSS Syntax Module</a>. 5 November 2013. W3C Working Draft. (Work in progress.) URL: <a href="http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/">http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/</a>
-   <dt id="biblio-css3val"><a class="self-link" href="#biblio-css3val"></a>[CSS3VAL]
-   <dd>Håkon Wium Lie; Tab Atkins Jr.; Elika Etemad. <a href="http://www.w3.org/TR/css3-values/">CSS Values and Units Module Level 3</a>. 30 July 2013. CR. URL: <a href="http://www.w3.org/TR/css3-values/">http://www.w3.org/TR/css3-values/</a>
-   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dt id="biblio-css-conditional-3">[CSS-CONDITIONAL-3]
+   <dd>CSS Conditional Rules Module Level 3 URL: <a href="https://drafts.csswg.org/css-conditional-3/">https://drafts.csswg.org/css-conditional-3/</a>
+   <dt id="biblio-css3syn">[CSS3SYN]
+   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://dev.w3.org/csswg/css-syntax/">CSS Syntax Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-syntax/">http://dev.w3.org/csswg/css-syntax/</a>
+   <dt id="biblio-css3val">[CSS3VAL]
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>. 29 September 2016. CR. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
+   <dt id="biblio-mediaqueries-4">[MEDIAQUERIES-4]
+   <dd>Florian Rivoal; Tab Atkins Jr.. <a href="https://drafts.csswg.org/mediaqueries-4/">Media Queries Level 4</a>. URL: <a href="https://drafts.csswg.org/mediaqueries-4/">https://drafts.csswg.org/mediaqueries-4/</a>
+   <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-  </dl></body>
-</html>
+   <dt id="biblio-selectors-4">[SELECTORS-4]
+   <dd>Selectors Level 4 URL: <a href="https://drafts.csswg.org/selectors-4/">https://drafts.csswg.org/selectors-4/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-css-content-3">[CSS-CONTENT-3]
+   <dd>Elika Etemad; Dave Cramer. <a href="https://drafts.csswg.org/css-content/">CSS Generated Content Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-content/">https://drafts.csswg.org/css-content/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="property-index"><span class="content">Property Index</span><a class="self-link" href="#property-index"></a></h2>
+  <p>No properties defined.</p>
+  <h3 class="no-num no-ref heading settled" id="element-descriptor-table"><span class="content"><a class="css" data-link-type="at-rule" href="#at-ruledef-element">@element</a> Descriptors</span><a class="self-link" href="#element-descriptor-table"></a></h3>
+  <div class="big-element-wrapper">
+   <table class="index">
+    <thead>
+     <tr>
+      <th scope="col">Name
+      <th scope="col">Value
+      <th scope="col">Initial
+      <th scope="col">Type
+    <tbody>
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-width">width</a>
+      <td>&lt;dimension>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-height">height</a>
+      <td>&lt;dimension>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-characters">characters</a>
+      <td>&lt;integer>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-lines">lines</a>
+      <td>&lt;integer>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-children">children</a>
+      <td>&lt;integer>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-scroll-y">scroll-y</a>
+      <td>&lt;dimension>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-scroll-x">scroll-x</a>
+      <td>&lt;dimension>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-aspect-ratio">aspect-ratio</a>
+      <td>&lt;ratio>
+      <td>
+      <td>range
+     <tr>
+      <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-element-orientation">orientation</a>
+      <td>portrait | square | landscape
+      <td>
+      <td>discrete
+   </table>
+  </div>
+  <aside class="dfn-panel" data-for="at-ruledef-element">
+   <b><a href="#at-ruledef-element">#at-ruledef-element</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-at-ruledef-element-1">1. Introduction</a>
+    <li><a href="#ref-for-at-ruledef-element-2">2.1. Scoped Styles</a>
+    <li><a href="#ref-for-at-ruledef-element-3">2.1.2. Understanding the Scope</a>
+    <li><a href="#ref-for-at-ruledef-element-4">2.2.2. Combining @element and @media queries</a>
+    <li><a href="#ref-for-at-ruledef-element-5">2.2.3. Self-Referential @element queries</a> <a href="#ref-for-at-ruledef-element-6">(2)</a> <a href="#ref-for-at-ruledef-element-7">(3)</a>
+    <li><a href="#ref-for-at-ruledef-element-8">2.2.4. Circular Referential @element queries</a> <a href="#ref-for-at-ruledef-element-9">(2)</a> <a href="#ref-for-at-ruledef-element-10">(3)</a> <a href="#ref-for-at-ruledef-element-11">(4)</a>
+    <li><a href="#ref-for-at-ruledef-element-12">5. Responsive Conditions</a>
+    <li><a href="#ref-for-at-ruledef-element-13">5.1. Width</a>
+    <li><a href="#ref-for-at-ruledef-element-14">5.2. Height</a>
+    <li><a href="#ref-for-at-ruledef-element-15">5.3. Characters</a>
+    <li><a href="#ref-for-at-ruledef-element-16">5.4. Lines</a>
+    <li><a href="#ref-for-at-ruledef-element-17">5.5. Children</a>
+    <li><a href="#ref-for-at-ruledef-element-18">5.6. Scroll-Y</a>
+    <li><a href="#ref-for-at-ruledef-element-19">5.7. Scroll-X</a>
+    <li><a href="#ref-for-at-ruledef-element-20">5.8. Aspect-Ratio</a>
+    <li><a href="#ref-for-at-ruledef-element-21">5.9. Orientation</a>
+    <li><a href="#ref-for-at-ruledef-element-22">8.6. Self-responsive Grid</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-eq-prelude">
+   <b><a href="#typedef-eq-prelude">#typedef-eq-prelude</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-eq-prelude-1">3. Syntax</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-eq-condition">
+   <b><a href="#typedef-eq-condition">#typedef-eq-condition</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-eq-condition-1">3. Syntax</a>
+    <li><a href="#ref-for-typedef-eq-condition-2">3.1. Evaluating Element Queries</a>
+    <li><a href="#ref-for-typedef-eq-condition-3">5. Responsive Conditions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-eq-name">
+   <b><a href="#typedef-eq-name">#typedef-eq-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-eq-name-1">3. Syntax</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-eq-value">
+   <b><a href="#typedef-eq-value">#typedef-eq-value</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-eq-value-1">3. Syntax</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors">
+   <b><a href="#selectordef-meta-selectors">#selectordef-meta-selectors</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-1">4. Meta-Selectors</a>
+    <li><a href="#ref-for-selectordef-meta-selectors-2">4.1. Diagram of meta-selectors</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="eq-unit">
+   <b><a href="#eq-unit">#eq-unit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eq-unit-1">7. Element-percentage Units</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="funcdef-eval">
+   <b><a href="#funcdef-eval">#funcdef-eval</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-funcdef-eval-1">6.1. eval("")</a> <a href="#ref-for-funcdef-eval-2">(2)</a> <a href="#ref-for-funcdef-eval-3">(3)</a>
+    <li><a href="#ref-for-funcdef-eval-4">6.1.1. Using JavaScript Variables in CSS</a>
+    <li><a href="#ref-for-funcdef-eval-5">6.1.2. Writing JavaScript in CSS</a>
+    <li><a href="#ref-for-funcdef-eval-6">6.1.3. Using JavaScript Functions in CSS</a>
+    <li><a href="#ref-for-funcdef-eval-7">6.1.4. Replacing Values in CSS</a>
+    <li><a href="#ref-for-funcdef-eval-8">6.1.5. Replacing Properties in CSS</a>
+    <li><a href="#ref-for-funcdef-eval-9">6.1.6. Replacing Selectors in CSS</a> <a href="#ref-for-funcdef-eval-10">(2)</a>
+    <li><a href="#ref-for-funcdef-eval-11">6.1.7. $it selector</a> <a href="#ref-for-funcdef-eval-12">(2)</a> <a href="#ref-for-funcdef-eval-13">(3)</a> <a href="#ref-for-funcdef-eval-14">(4)</a>
+    <li><a href="#ref-for-funcdef-eval-15">8.2. Wrapper-free responsive iframe resize</a>
+    <li><a href="#ref-for-funcdef-eval-16">8.4. Auto-expanding textarea</a>
+    <li><a href="#ref-for-funcdef-eval-17">8.5. Display Browser Dimensions</a>
+    <li><a href="#ref-for-funcdef-eval-18">8.7. Using Variables as Selectors</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors-this">
+   <b><a href="#selectordef-meta-selectors-this">#selectordef-meta-selectors-this</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-this-1">4.1. Diagram of meta-selectors</a> <a href="#ref-for-selectordef-meta-selectors-this-2">(2)</a> <a href="#ref-for-selectordef-meta-selectors-this-3">(3)</a> <a href="#ref-for-selectordef-meta-selectors-this-4">(4)</a> <a href="#ref-for-selectordef-meta-selectors-this-5">(5)</a>
+    <li><a href="#ref-for-selectordef-meta-selectors-this-6">8.6. Self-responsive Grid</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors-parent">
+   <b><a href="#selectordef-meta-selectors-parent">#selectordef-meta-selectors-parent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-parent-1">4.1. Diagram of meta-selectors</a> <a href="#ref-for-selectordef-meta-selectors-parent-2">(2)</a> <a href="#ref-for-selectordef-meta-selectors-parent-3">(3)</a> <a href="#ref-for-selectordef-meta-selectors-parent-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors-prev">
+   <b><a href="#selectordef-meta-selectors-prev">#selectordef-meta-selectors-prev</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-prev-1">4.1. Diagram of meta-selectors</a> <a href="#ref-for-selectordef-meta-selectors-prev-2">(2)</a> <a href="#ref-for-selectordef-meta-selectors-prev-3">(3)</a> <a href="#ref-for-selectordef-meta-selectors-prev-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors-next">
+   <b><a href="#selectordef-meta-selectors-next">#selectordef-meta-selectors-next</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-next-1">4.1. Diagram of meta-selectors</a> <a href="#ref-for-selectordef-meta-selectors-next-2">(2)</a> <a href="#ref-for-selectordef-meta-selectors-next-3">(3)</a> <a href="#ref-for-selectordef-meta-selectors-next-4">(4)</a> <a href="#ref-for-selectordef-meta-selectors-next-5">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-width">
+   <b><a href="#descdef-element-width">#descdef-element-width</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-width-1">5.1. Width</a> <a href="#ref-for-descdef-element-width-2">(2)</a> <a href="#ref-for-descdef-element-width-3">(3)</a> <a href="#ref-for-descdef-element-width-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-height">
+   <b><a href="#descdef-element-height">#descdef-element-height</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-height-1">5.2. Height</a> <a href="#ref-for-descdef-element-height-2">(2)</a> <a href="#ref-for-descdef-element-height-3">(3)</a> <a href="#ref-for-descdef-element-height-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-characters">
+   <b><a href="#descdef-element-characters">#descdef-element-characters</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-characters-1">5.3. Characters</a> <a href="#ref-for-descdef-element-characters-2">(2)</a> <a href="#ref-for-descdef-element-characters-3">(3)</a> <a href="#ref-for-descdef-element-characters-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-lines">
+   <b><a href="#descdef-element-lines">#descdef-element-lines</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-lines-1">5.4. Lines</a> <a href="#ref-for-descdef-element-lines-2">(2)</a> <a href="#ref-for-descdef-element-lines-3">(3)</a> <a href="#ref-for-descdef-element-lines-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-children">
+   <b><a href="#descdef-element-children">#descdef-element-children</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-children-1">5.5. Children</a> <a href="#ref-for-descdef-element-children-2">(2)</a> <a href="#ref-for-descdef-element-children-3">(3)</a> <a href="#ref-for-descdef-element-children-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-scroll-y">
+   <b><a href="#descdef-element-scroll-y">#descdef-element-scroll-y</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-scroll-y-1">5.6. Scroll-Y</a> <a href="#ref-for-descdef-element-scroll-y-2">(2)</a> <a href="#ref-for-descdef-element-scroll-y-3">(3)</a> <a href="#ref-for-descdef-element-scroll-y-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-scroll-x">
+   <b><a href="#descdef-element-scroll-x">#descdef-element-scroll-x</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-scroll-x-1">5.7. Scroll-X</a> <a href="#ref-for-descdef-element-scroll-x-2">(2)</a> <a href="#ref-for-descdef-element-scroll-x-3">(3)</a> <a href="#ref-for-descdef-element-scroll-x-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-aspect-ratio">
+   <b><a href="#descdef-element-aspect-ratio">#descdef-element-aspect-ratio</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-aspect-ratio-1">5.8. Aspect-Ratio</a> <a href="#ref-for-descdef-element-aspect-ratio-2">(2)</a> <a href="#ref-for-descdef-element-aspect-ratio-3">(3)</a> <a href="#ref-for-descdef-element-aspect-ratio-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="descdef-element-orientation">
+   <b><a href="#descdef-element-orientation">#descdef-element-orientation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-descdef-element-orientation-1">5.9. Orientation</a>
+    <li><a href="#ref-for-descdef-element-orientation-2">5.9.1. Portrait Orientation</a>
+    <li><a href="#ref-for-descdef-element-orientation-3">5.9.2. Square Orientation</a>
+    <li><a href="#ref-for-descdef-element-orientation-4">5.9.3. Landscape Orientation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valdef-element-orientation-portrait">
+   <b><a href="#valdef-element-orientation-portrait">#valdef-element-orientation-portrait</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valdef-element-orientation-portrait-1">5.9. Orientation</a>
+    <li><a href="#ref-for-valdef-element-orientation-portrait-2">5.9.1. Portrait Orientation</a> <a href="#ref-for-valdef-element-orientation-portrait-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valdef-element-orientation-square">
+   <b><a href="#valdef-element-orientation-square">#valdef-element-orientation-square</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valdef-element-orientation-square-1">5.9. Orientation</a>
+    <li><a href="#ref-for-valdef-element-orientation-square-2">5.9.2. Square Orientation</a> <a href="#ref-for-valdef-element-orientation-square-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valdef-element-orientation-landscape">
+   <b><a href="#valdef-element-orientation-landscape">#valdef-element-orientation-landscape</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valdef-element-orientation-landscape-1">5.9. Orientation</a>
+    <li><a href="#ref-for-valdef-element-orientation-landscape-2">5.9.3. Landscape Orientation</a> <a href="#ref-for-valdef-element-orientation-landscape-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="selectordef-meta-selectors-it">
+   <b><a href="#selectordef-meta-selectors-it">#selectordef-meta-selectors-it</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-selectordef-meta-selectors-it-1">6.1.7. $it selector</a> <a href="#ref-for-selectordef-meta-selectors-it-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="ew">
+   <b><a href="#ew">#ew</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ew-1">7. Element-percentage Units</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="eh">
+   <b><a href="#eh">#eh</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eh-1">7. Element-percentage Units</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="emin">
+   <b><a href="#emin">#emin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-emin-1">7. Element-percentage Units</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="emax">
+   <b><a href="#emax">#emax</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-emax-1">7. Element-percentage Units</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
+
+        });
+        </script>


### PR DESCRIPTION
I notice there's been no update here for almost 2 years, so let's see if we can breathe some new life into this!

This spec covers a container-style element query syntax for CSS that can (as of the version I'm bringing in today) be tested using the EQCSS plugin.

I've been using this syntax for a couple of years in production, and it's evolved over that time to include some features that weren't immediately apparent that we would need them at the start, so before making serious alterations to the proposed syntax I'd ask that people first attempt to use the syntax and the features as they are to suggest better improvements/replacements!

There are many examples of this syntax in use that can be tested, modified, and interacted with here: http://codepen.io/search/pens?q=eqcss&limit=all&type=type-pens